### PR TITLE
feat: allow changing drawable gender

### DIFF
--- a/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml
+++ b/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml
@@ -79,6 +79,7 @@
                                             <c:ModernLabelTextBox Width="75" Label="Position" Text="{Binding SelectedAddon.SelectedDrawable.Number}" Margin="2" FontSize="18" HorizontalAlignment="Center" />
                                             <c:ModernLabelTextBox Width="150" Label="Name" Text="{Binding SelectedAddon.SelectedDrawable.Name, UpdateSourceTrigger=PropertyChanged}" Margin="2"/>
                                             <c:ModernLabelComboBox Width="125" Label="Drawable type" SelectedItem="{Binding SelectedAddon.SelectedDrawable.TypeName, Mode=TwoWay}" ItemsSource="{Binding SelectedAddon.SelectedDrawable.AvailableTypes}" IsUpdated="DrawableType_Changed" />
+                                            <c:ModernLabelComboBox Width="75" Label="Sex" SelectedItem="{Binding SelectedAddon.SelectedDrawable.SexName, Mode=TwoWay}" ItemsSource="{Binding SelectedAddon.SelectedDrawable.AvailableSex}" IsUpdated="DrawableSex_Changed" />
                                         </StackPanel>
                                     </StackPanel>
                                     <StackPanel Visibility="{Binding SelectedAddon.SelectedDrawable.IsReserved, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="-60" Grid.Row="1">

--- a/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml.cs
+++ b/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml.cs
@@ -305,6 +305,25 @@ namespace grzyClothTool.Controls
             SaveHelper.SetUnsavedChanges(true);
         }
 
+        private void DrawableSex_Changed(object sender, UpdatedEventArgs e)
+        {
+            if (!e.IsUserInitiated)
+            {
+                return;
+            }
+
+            var newValue = e.DependencyPropertyChangedEventArgs.NewValue;
+            var oldValue = e.DependencyPropertyChangedEventArgs.OldValue;
+
+            if ((newValue == null || oldValue == null) || newValue == oldValue)
+            {
+                return;
+            }
+
+            SelectedDraw.ChangeDrawableSex(newValue.ToString());
+            SaveHelper.SetUnsavedChanges(true);
+        }
+
         private async void ReplaceReserved_Click(object sender, RoutedEventArgs e)
         {
             OpenFileDialog file = new()

--- a/grzyClothTool/Enums.cs
+++ b/grzyClothTool/Enums.cs
@@ -6,6 +6,12 @@ namespace grzyClothTool
 {
     public class Enums
     {
+
+        public enum Sex
+        {
+            female = 0,
+            male = 1
+        }
         public enum ComponentNumbers
         {
             head = 0,

--- a/grzyClothTool/Helpers/EnumHelper.cs
+++ b/grzyClothTool/Helpers/EnumHelper.cs
@@ -13,6 +13,11 @@ public static class EnumHelper
         return Enum.GetName(enumType, type);
     }
 
+    public static string GetSex(bool isMale)
+    {
+        return Enum.GetName(typeof(Enums.Sex), isMale ? 1 : 0);
+    }
+
     public static int GetValue(string type, bool isProp)
     {
         Type enumType = isProp ? typeof(Enums.PropNumbers) : typeof(Enums.ComponentNumbers);
@@ -160,6 +165,14 @@ public static class EnumHelper
     {
         return Enum.GetValues(typeof(PropNumbers))
             .Cast<PropNumbers>()
+            .Select(item => item.ToString())
+            .ToList();
+    }
+
+    public static List<string> GetSexTypeList()
+    {
+        return Enum.GetValues(typeof(Sex))
+            .Cast<Sex>()
             .Select(item => item.ToString())
             .ToList();
     }


### PR DESCRIPTION
Allows changing gender without re-adding drawables.
This is useful when bulk-adding clothes without specifying gender at the time of addition.