### PR TITLE
feat: add texture export functionality

### DIFF
--- a/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml
+++ b/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml
@@ -175,6 +175,8 @@
                                                     <Grid.ContextMenu>
                                                         <ContextMenu>
                                                             <MenuItem Header="Optimize texture" Click="OptimizeTexture_Click" />
+                                                            <MenuItem Header="Export texture as DDS" Click="ExportTexture_Click" Tag="DDS"/>
+                                                            <MenuItem Header="Export texture as PNG" Click="ExportTexture_Click" Tag="PNG"/>
                                                         </ContextMenu>
                                                     </Grid.ContextMenu>
                                                 </Grid>


### PR DESCRIPTION
Implements texture export functionality,
Allows users to select a folder and export textures in DDS or PNG format. 

![image](https://github.com/user-attachments/assets/67f1f3cf-dd98-4016-a2bd-3c4051eb9ef4)
