### PR TITLE
feat: new camera options

### DIFF
--- a/CodeWalker/CodeWalker/CustomPedsForm.Designer.cs
+++ b/CodeWalker/CodeWalker/CustomPedsForm.Designer.cs
@@ -15,10 +15,19 @@ namespace CodeWalker
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                if (components != null)
+                {
+                    components.Dispose();
+                }
+                if (autoRotateTimer != null)
+                {
+                    autoRotateTimer.Stop();
+                    autoRotateTimer.Dispose();
+                }
             }
+
             base.Dispose(disposing);
         }
 
@@ -67,6 +76,8 @@ namespace CodeWalker
             this.normalRadio = new System.Windows.Forms.RadioButton();
             this.TexturesTreeView = new CodeWalker.WinForms.TreeViewFix();
             this.ToolsOptionsTabPage = new System.Windows.Forms.TabPage();
+            this.OnlySelectedCheckBox = new System.Windows.Forms.CheckBox();
+            this.AutoRotatePedCheckBox = new System.Windows.Forms.CheckBox();
             this.label7 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
@@ -101,6 +112,7 @@ namespace CodeWalker
             this.head_updown = new System.Windows.Forms.NumericUpDown();
             this.StatusBarCheckBox = new System.Windows.Forms.CheckBox();
             this.ErrorConsoleCheckBox = new System.Windows.Forms.CheckBox();
+            this.btn_restartCamera = new System.Windows.Forms.Button();
             this.ConsolePanel.SuspendLayout();
             this.StatusStrip.SuspendLayout();
             this.ToolsPanel.SuspendLayout();
@@ -510,6 +522,9 @@ namespace CodeWalker
             // 
             // ToolsOptionsTabPage
             // 
+            this.ToolsOptionsTabPage.Controls.Add(this.btn_restartCamera);
+            this.ToolsOptionsTabPage.Controls.Add(this.OnlySelectedCheckBox);
+            this.ToolsOptionsTabPage.Controls.Add(this.AutoRotatePedCheckBox);
             this.ToolsOptionsTabPage.Controls.Add(this.label7);
             this.ToolsOptionsTabPage.Controls.Add(this.label6);
             this.ToolsOptionsTabPage.Controls.Add(this.label5);
@@ -550,6 +565,28 @@ namespace CodeWalker
             this.ToolsOptionsTabPage.TabIndex = 3;
             this.ToolsOptionsTabPage.Text = "Options";
             this.ToolsOptionsTabPage.UseVisualStyleBackColor = true;
+            // 
+            // OnlySelectedCheckBox
+            // 
+            this.OnlySelectedCheckBox.AutoSize = true;
+            this.OnlySelectedCheckBox.Location = new System.Drawing.Point(12, 369);
+            this.OnlySelectedCheckBox.Name = "OnlySelectedCheckBox";
+            this.OnlySelectedCheckBox.Size = new System.Drawing.Size(140, 17);
+            this.OnlySelectedCheckBox.TabIndex = 68;
+            this.OnlySelectedCheckBox.Text = "Only Selected Drawable";
+            this.OnlySelectedCheckBox.UseVisualStyleBackColor = true;
+            this.OnlySelectedCheckBox.CheckedChanged += new System.EventHandler(this.OnlySelectedCheckBox_CheckedChanged);
+            // 
+            // AutoRotatePedCheckBox
+            // 
+            this.AutoRotatePedCheckBox.AutoSize = true;
+            this.AutoRotatePedCheckBox.Location = new System.Drawing.Point(12, 346);
+            this.AutoRotatePedCheckBox.Name = "AutoRotatePedCheckBox";
+            this.AutoRotatePedCheckBox.Size = new System.Drawing.Size(100, 17);
+            this.AutoRotatePedCheckBox.TabIndex = 67;
+            this.AutoRotatePedCheckBox.Text = "Auto rotate Ped";
+            this.AutoRotatePedCheckBox.UseVisualStyleBackColor = true;
+            this.AutoRotatePedCheckBox.CheckedChanged += new System.EventHandler(this.AutoRotatePedCheckBox_CheckedChanged);
             // 
             // label7
             // 
@@ -604,7 +641,7 @@ namespace CodeWalker
             // WireframeCheckBox
             // 
             this.WireframeCheckBox.AutoSize = true;
-            this.WireframeCheckBox.Location = new System.Drawing.Point(10, 321);
+            this.WireframeCheckBox.Location = new System.Drawing.Point(12, 323);
             this.WireframeCheckBox.Name = "WireframeCheckBox";
             this.WireframeCheckBox.Size = new System.Drawing.Size(74, 17);
             this.WireframeCheckBox.TabIndex = 60;
@@ -615,7 +652,7 @@ namespace CodeWalker
             // SkeletonsCheckBox
             // 
             this.SkeletonsCheckBox.AutoSize = true;
-            this.SkeletonsCheckBox.Location = new System.Drawing.Point(10, 298);
+            this.SkeletonsCheckBox.Location = new System.Drawing.Point(12, 300);
             this.SkeletonsCheckBox.Name = "SkeletonsCheckBox";
             this.SkeletonsCheckBox.Size = new System.Drawing.Size(103, 17);
             this.SkeletonsCheckBox.TabIndex = 59;
@@ -628,7 +665,7 @@ namespace CodeWalker
             this.ShadowsCheckBox.AutoSize = true;
             this.ShadowsCheckBox.Checked = true;
             this.ShadowsCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.ShadowsCheckBox.Location = new System.Drawing.Point(10, 275);
+            this.ShadowsCheckBox.Location = new System.Drawing.Point(12, 277);
             this.ShadowsCheckBox.Name = "ShadowsCheckBox";
             this.ShadowsCheckBox.Size = new System.Drawing.Size(70, 17);
             this.ShadowsCheckBox.TabIndex = 58;
@@ -639,7 +676,7 @@ namespace CodeWalker
             // HDRRenderingCheckBox
             // 
             this.HDRRenderingCheckBox.AutoSize = true;
-            this.HDRRenderingCheckBox.Location = new System.Drawing.Point(10, 254);
+            this.HDRRenderingCheckBox.Location = new System.Drawing.Point(12, 254);
             this.HDRRenderingCheckBox.Name = "HDRRenderingCheckBox";
             this.HDRRenderingCheckBox.Size = new System.Drawing.Size(97, 17);
             this.HDRRenderingCheckBox.TabIndex = 57;
@@ -661,7 +698,7 @@ namespace CodeWalker
             "Texture coord 1",
             "Texture coord 2",
             "Texture coord 3"});
-            this.RenderModeComboBox.Location = new System.Drawing.Point(81, 389);
+            this.RenderModeComboBox.Location = new System.Drawing.Point(83, 400);
             this.RenderModeComboBox.Name = "RenderModeComboBox";
             this.RenderModeComboBox.Size = new System.Drawing.Size(114, 21);
             this.RenderModeComboBox.TabIndex = 52;
@@ -670,7 +707,7 @@ namespace CodeWalker
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(5, 419);
+            this.label11.Location = new System.Drawing.Point(7, 430);
             this.label11.Name = "label11";
             this.label11.Size = new System.Drawing.Size(67, 13);
             this.label11.TabIndex = 53;
@@ -681,7 +718,7 @@ namespace CodeWalker
             this.TextureSamplerComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.TextureSamplerComboBox.Enabled = false;
             this.TextureSamplerComboBox.FormattingEnabled = true;
-            this.TextureSamplerComboBox.Location = new System.Drawing.Point(81, 416);
+            this.TextureSamplerComboBox.Location = new System.Drawing.Point(83, 427);
             this.TextureSamplerComboBox.Name = "TextureSamplerComboBox";
             this.TextureSamplerComboBox.Size = new System.Drawing.Size(114, 21);
             this.TextureSamplerComboBox.TabIndex = 54;
@@ -696,7 +733,7 @@ namespace CodeWalker
             "Texture coord 1",
             "Texture coord 2",
             "Texture coord 3"});
-            this.TextureCoordsComboBox.Location = new System.Drawing.Point(81, 443);
+            this.TextureCoordsComboBox.Location = new System.Drawing.Point(83, 454);
             this.TextureCoordsComboBox.Name = "TextureCoordsComboBox";
             this.TextureCoordsComboBox.Size = new System.Drawing.Size(114, 21);
             this.TextureCoordsComboBox.TabIndex = 56;
@@ -705,7 +742,7 @@ namespace CodeWalker
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(5, 392);
+            this.label10.Location = new System.Drawing.Point(7, 403);
             this.label10.Name = "label10";
             this.label10.Size = new System.Drawing.Size(74, 13);
             this.label10.TabIndex = 51;
@@ -714,7 +751,7 @@ namespace CodeWalker
             // label14
             // 
             this.label14.AutoSize = true;
-            this.label14.Location = new System.Drawing.Point(5, 446);
+            this.label14.Location = new System.Drawing.Point(7, 457);
             this.label14.Name = "label14";
             this.label14.Size = new System.Drawing.Size(63, 13);
             this.label14.TabIndex = 55;
@@ -723,7 +760,7 @@ namespace CodeWalker
             // TimeOfDayLabel
             // 
             this.TimeOfDayLabel.AutoSize = true;
-            this.TimeOfDayLabel.Location = new System.Drawing.Point(78, 496);
+            this.TimeOfDayLabel.Location = new System.Drawing.Point(80, 507);
             this.TimeOfDayLabel.Name = "TimeOfDayLabel";
             this.TimeOfDayLabel.Size = new System.Drawing.Size(34, 13);
             this.TimeOfDayLabel.TabIndex = 49;
@@ -732,7 +769,7 @@ namespace CodeWalker
             // label19
             // 
             this.label19.AutoSize = true;
-            this.label19.Location = new System.Drawing.Point(7, 496);
+            this.label19.Location = new System.Drawing.Point(9, 507);
             this.label19.Name = "label19";
             this.label19.Size = new System.Drawing.Size(65, 13);
             this.label19.TabIndex = 48;
@@ -744,7 +781,7 @@ namespace CodeWalker
             | System.Windows.Forms.AnchorStyles.Right)));
             this.TimeOfDayTrackBar.BackColor = System.Drawing.SystemColors.ControlLightLight;
             this.TimeOfDayTrackBar.LargeChange = 60;
-            this.TimeOfDayTrackBar.Location = new System.Drawing.Point(9, 512);
+            this.TimeOfDayTrackBar.Location = new System.Drawing.Point(10, 536);
             this.TimeOfDayTrackBar.Maximum = 1440;
             this.TimeOfDayTrackBar.Name = "TimeOfDayTrackBar";
             this.TimeOfDayTrackBar.Size = new System.Drawing.Size(222, 45);
@@ -756,7 +793,7 @@ namespace CodeWalker
             // ControlLightDirCheckBox
             // 
             this.ControlLightDirCheckBox.AutoSize = true;
-            this.ControlLightDirCheckBox.Location = new System.Drawing.Point(9, 476);
+            this.ControlLightDirCheckBox.Location = new System.Drawing.Point(11, 487);
             this.ControlLightDirCheckBox.Name = "ControlLightDirCheckBox";
             this.ControlLightDirCheckBox.Size = new System.Drawing.Size(124, 17);
             this.ControlLightDirCheckBox.TabIndex = 47;
@@ -766,7 +803,7 @@ namespace CodeWalker
             // 
             // Save_defaultComp
             // 
-            this.Save_defaultComp.Location = new System.Drawing.Point(16, 198);
+            this.Save_defaultComp.Location = new System.Drawing.Point(10, 189);
             this.Save_defaultComp.Name = "Save_defaultComp";
             this.Save_defaultComp.Size = new System.Drawing.Size(94, 26);
             this.Save_defaultComp.TabIndex = 38;
@@ -918,6 +955,16 @@ namespace CodeWalker
             this.ErrorConsoleCheckBox.UseVisualStyleBackColor = true;
             this.ErrorConsoleCheckBox.CheckedChanged += new System.EventHandler(this.ErrorConsoleCheckBox_CheckedChanged);
             // 
+            // btn_restartCamera
+            // 
+            this.btn_restartCamera.Location = new System.Drawing.Point(10, 221);
+            this.btn_restartCamera.Name = "btn_restartCamera";
+            this.btn_restartCamera.Size = new System.Drawing.Size(94, 26);
+            this.btn_restartCamera.TabIndex = 69;
+            this.btn_restartCamera.Text = "Restart Camera";
+            this.btn_restartCamera.UseVisualStyleBackColor = true;
+            this.btn_restartCamera.Click += new System.EventHandler(this.RestartCamera_Click);
+            // 
             // CustomPedsForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1037,5 +1084,8 @@ namespace CodeWalker
         private System.Windows.Forms.RadioButton diffuseRadio;
         private System.Windows.Forms.Button liveTxtButton;
         private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.CheckBox AutoRotatePedCheckBox;
+        private System.Windows.Forms.CheckBox OnlySelectedCheckBox;
+        private System.Windows.Forms.Button btn_restartCamera;
     }
 }

--- a/CodeWalker/CodeWalker/CustomPedsForm.cs
+++ b/CodeWalker/CodeWalker/CustomPedsForm.cs
@@ -96,6 +96,11 @@ namespace CodeWalker
         };
 
         private bool highheelvaluechanged = false;
+        private bool renderOnlySelected = false;
+
+        private System.Windows.Forms.Timer autoRotateTimer;
+        private float autoRotateAngle = 0f;
+        private const float AutoRotateSpeed = 1.0f;
 
         public class ComponentComboItem
         {
@@ -173,6 +178,10 @@ namespace CodeWalker
 
             Renderer.renderskydome = false;
             Renderer.renderhdtextures = true;
+
+            autoRotateTimer = new System.Windows.Forms.Timer();
+            autoRotateTimer.Interval = 16; // About 60 FPS
+            autoRotateTimer.Tick += AutoRotateTimer_Tick;
         }
 
         public override void Refresh()
@@ -197,15 +206,7 @@ namespace CodeWalker
             }
 
 
-            camera.FollowEntity = camEntity;
-            camera.FollowEntity.Position = Vector3.Zero;// prevworldpos;
-            camera.FollowEntity.Orientation = Quaternion.LookAtLH(Vector3.Zero, Vector3.Up, Vector3.ForwardLH);
-            camera.TargetDistance = 2.0f;
-            camera.CurrentDistance = 2.0f;
-            camera.TargetRotation.Y = 0.2f;
-            camera.CurrentRotation.Y = 0.2f;
-            camera.TargetRotation.X = 1.0f * (float)Math.PI;
-            camera.CurrentRotation.X = 1.0f * (float)Math.PI;
+            SetDefaultCameraPosition();
 
             Renderer.shaders.deferred = false; //no point using this here yet
             Renderer.shaders.AnisotropicFiltering = true;
@@ -738,15 +739,32 @@ namespace CodeWalker
 
             if (SelectedPed == null) return;
 
-
-            for (int i = 0; i < 12; i++)
+            // The following could be combined into a single for loop with a conditional check inside
+            if (!renderOnlySelected)
             {
-                var drawable = SelectedPed.Drawables[i];
-                var drawablename = SelectedPed.DrawableNames[i];
-
-                if (drawable != null)
+                for (int i = 0; i < 12; i++)
                 {
-                    AddDrawableTreeNode(drawable, drawablename, true);
+                    var drawable = SelectedPed.Drawables[i];
+                    var drawablename = SelectedPed.DrawableNames[i];
+
+                    if (drawable != null)
+                    {
+                        AddDrawableTreeNode(drawable, drawablename, true);
+                    }
+                }
+            }
+            else
+            {
+                // Disabling rendering for all drawables.
+                // Code below this for loop will override this flag for the drawable(s) we want to render.
+                for (int i = 0; i < 12; i++)
+                {
+                    var drawable = SelectedPed.Drawables[i];
+
+                    if (drawable != null)
+                    {
+                        Renderer.SelectionDrawableDrawFlags[drawable] = false;
+                    }
                 }
             }
 
@@ -1528,6 +1546,71 @@ namespace CodeWalker
                         break;
                 }
             }
+        }
+
+        private void AutoRotateTimer_Tick(object sender, EventArgs e)
+        {
+            if (SelectedPed != null)
+            {
+                autoRotateAngle += AutoRotateSpeed * (float)Math.PI / 180f;
+                if (autoRotateAngle > 2 * Math.PI) // Keep the autoRotateAngle within the 0 to 360
+                {
+                    autoRotateAngle -= 2 * (float)Math.PI;
+                }
+
+                Quaternion newRotation = Quaternion.RotationYawPitchRoll(0, 0, autoRotateAngle);
+                SelectedPed.Rotation = newRotation;
+                SelectedPed.UpdateEntity();
+            }
+        }
+
+        private void AutoRotatePedCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            if (AutoRotatePedCheckBox.Checked)
+            {
+                autoRotateTimer.Start();
+            }
+            else
+            {
+                autoRotateTimer.Stop();
+            }
+        }
+
+        private void OnlySelectedCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            if (OnlySelectedCheckBox.Checked == renderOnlySelected) { return; }
+            renderOnlySelected = OnlySelectedCheckBox.Checked;
+            
+            UpdateModelsUI();
+        }
+
+        private void SetDefaultCameraPosition()
+        {
+            camera.FollowEntity = camEntity;
+            camera.FollowEntity.Position = Vector3.Zero;// prevworldpos;
+
+            // used to be Vector3.ForwardLH, but default animations rotates ped, so changed it to Vector3.ForwardRH 
+            camera.FollowEntity.Orientation = Quaternion.LookAtLH(Vector3.Zero, Vector3.Up, Vector3.ForwardRH); 
+
+            camera.TargetDistance = 2.0f;
+            camera.CurrentDistance = 2.0f;
+            camera.TargetRotation.Y = 0.2f;
+            camera.CurrentRotation.Y = 0.2f;
+            camera.TargetRotation.X = 1.0f * (float)Math.PI;
+            camera.CurrentRotation.X = 1.0f * (float)Math.PI;
+
+            if (SelectedPed != null)
+            {
+                // restart rotation angle, so ped faces camera
+                autoRotateAngle = 0f;
+                SelectedPed.Rotation = Quaternion.Identity;
+                SelectedPed.UpdateEntity();
+            }
+        }
+
+        private void RestartCamera_Click(object sender, EventArgs e)
+        {
+            SetDefaultCameraPosition();
         }
     }
 }


### PR DESCRIPTION
This PR adds improvements to the drawable preview:
- Automatic Ped Rotation
- Camera Reset Button to quickly restore the default view
- "Only selected drawable" - option for toggling between rendering all drawables or just the selected one
- Ped faces camera on start

![image](https://github.com/user-attachments/assets/f42bb8e9-5f11-452c-8bc3-4909b1121aa9)
