### PR TITLE
fix: 3D preview for textures from image files

### DIFF
--- a/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml.cs
+++ b/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml.cs
@@ -255,7 +255,7 @@ namespace grzyClothTool.Controls
             OpenFileDialog files = new()
             {
                 Title = $"Select textures",
-                Filter = "Texture files (*.ytd)|*.ytd|Image files (*.jpg;*.png)|*.jpg;*.png",
+                Filter = "Texture files (*.ytd)|*.ytd|Image files (*.jpg;*.png;*.dds)|*.jpg;*.png;*.dds",
                 Multiselect = true
             };
 

--- a/grzyClothTool/Helpers/CWHelper.cs
+++ b/grzyClothTool/Helpers/CWHelper.cs
@@ -1,6 +1,9 @@
 ﻿using CodeWalker;
 using CodeWalker.GameFiles;
+using grzyClothTool.Models.Texture;
+using System;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace grzyClothTool.Helpers;
 public static class CWHelper
@@ -48,9 +51,14 @@ public static class CWHelper
         return _ytdFile;
     }
 
-    public static YtdFile CreateYtdFile(string path, string name)
+    public static YtdFile CreateYtdFile(GTexture texture, string name)
     {
-        byte[] data = File.ReadAllBytes(path);
+        byte[] data = texture.Extension switch
+        {
+            ".ytd" => File.ReadAllBytes(texture.FilePath), // Read existing YTD file directly
+            ".png" or ".jpg" or ".dds" => ImgHelper.CreateDDS(texture), // Create DDS texture
+            _ => throw new NotSupportedException($"Unsupported file extension: {texture.Extension}"),
+        };
 
         RpfFileEntry rpf = RpfFile.CreateResourceFileEntry(ref data, 0);
         var decompressedData = ResourceBuilder.Decompress(data);

--- a/grzyClothTool/Helpers/ImgHelper.cs
+++ b/grzyClothTool/Helpers/ImgHelper.cs
@@ -87,6 +87,38 @@ public static class ImgHelper
         return bytes;
     }
 
+    public static byte[] GetDDSBytes(GTexture gtxt)
+    {
+        var ytd = new YtdFile
+        {
+            TextureDict = new TextureDictionary()
+        };
+
+        byte[] ddsBytes = [];
+
+        if (gtxt.Extension == ".dds")
+        {
+            ddsBytes = File.ReadAllBytes(gtxt.FilePath);
+        } 
+        else if (gtxt.Extension == ".jpg" || gtxt.Extension == ".png")
+        {
+            using var img = GetImage(gtxt.FilePath);
+            img.Format = MagickFormat.Dds;
+
+            var stream = new MemoryStream();
+            img.Write(stream);
+
+            ddsBytes = stream.ToArray();
+        }
+
+        var newTxt = CodeWalker.Utils.DDSIO.GetTexture(ddsBytes);
+
+        newTxt.Name = gtxt.DisplayName;
+        ytd.TextureDict.BuildFromTextureList([newTxt]);
+
+        return ytd.Save();
+    }
+
     private static string GetCompressionString(string cwCompression)
     {
         return cwCompression switch

--- a/grzyClothTool/Models/Texture/GTexture.cs
+++ b/grzyClothTool/Models/Texture/GTexture.cs
@@ -155,7 +155,7 @@ public class GTexture : INotifyPropertyChanged
                 Name = txt.Name
             };
         }
-        else if (extension == ".jpg" || extension == ".png")
+        else if (extension == ".jpg" || extension == ".png" || extension == ".dds")
         {
             using var img = new MagickImage(bytes);
 

--- a/grzyClothTool/Views/ProjectWindow.xaml.cs
+++ b/grzyClothTool/Views/ProjectWindow.xaml.cs
@@ -22,6 +22,7 @@ using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using System.Windows.Input;
 using grzyClothTool.Models.Drawable;
 using grzyClothTool.Models.Texture;
+using System.Threading.Tasks;
 
 namespace grzyClothTool.Views
 {
@@ -229,7 +230,7 @@ namespace grzyClothTool.Views
 
             if (Addon.SelectedTexture != null)
             {
-                var ytd = CWHelper.CreateYtdFile(Addon.SelectedTexture.FilePath, Addon.SelectedTexture.DisplayName);
+                var ytd = CWHelper.CreateYtdFile(Addon.SelectedTexture, Addon.SelectedTexture.DisplayName);
                 CWHelper.CWForm.LoadedTexture = ytd.TextureDict;
             }
 
@@ -273,7 +274,7 @@ namespace grzyClothTool.Views
             YtdFile ytd = null;
             if (Addon.SelectedTexture != null)
             {
-                ytd = CWHelper.CreateYtdFile(Addon.SelectedTexture.FilePath, Addon.SelectedTexture.DisplayName);
+                ytd = CWHelper.CreateYtdFile(Addon.SelectedTexture, Addon.SelectedTexture.DisplayName);
                 CWHelper.CWForm.LoadedTexture = ytd.TextureDict;
             }
 
@@ -326,7 +327,7 @@ namespace grzyClothTool.Views
 
             if (!MainWindow.AddonManager.IsPreviewEnabled) return;
 
-            var ytd = CWHelper.CreateYtdFile(Addon.SelectedTexture.FilePath, Addon.SelectedTexture.DisplayName);
+            var ytd = CWHelper.CreateYtdFile(Addon.SelectedTexture, Addon.SelectedTexture.DisplayName);
             CWHelper.CWForm.LoadedTexture = ytd.TextureDict;
             CWHelper.CWForm.Refresh();
         }


### PR DESCRIPTION
Fix 3D preview for image-imported textures
Load times for some textures may be slow

Notes:
- Investigate performance
- Consider adding .dds support - would allow for skipping some steps, when building ytd (?)