### PR TITLE
feat(build): add progress reporting and disable button during build

### DIFF
--- a/grzyClothTool/Models/Addon.cs
+++ b/grzyClothTool/Models/Addon.cs
@@ -110,6 +110,11 @@ public class Addon : INotifyPropertyChanged
         return nextNumber;
     }
 
+    public int GetTotalDrawableAndTextureCount()
+    {
+        return Drawables.Count + Drawables.SelectMany(drawable => drawable.Textures).Count();
+    }
+
     protected void OnPropertyChanged([CallerMemberName] string name = null)
     {
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));

--- a/grzyClothTool/Models/AddonManager.cs
+++ b/grzyClothTool/Models/AddonManager.cs
@@ -48,7 +48,6 @@ namespace grzyClothTool.Models
             }
         }
 
-        
         private Addon _selectedAddon;
         [JsonIgnore]
         public Addon SelectedAddon
@@ -281,6 +280,11 @@ namespace grzyClothTool.Models
             {
                 addon.Drawables.Sort();
             }
+        }
+
+        public int GetTotalDrawableAndTextureCount()
+        {
+            return _addons.Sum(addon => addon.GetTotalDrawableAndTextureCount());
         }
 
         protected void OnPropertyChanged([CallerMemberName] string name = null)

--- a/grzyClothTool/Views/BuildWindow.xaml
+++ b/grzyClothTool/Views/BuildWindow.xaml
@@ -9,6 +9,7 @@
         ResizeMode="NoResize"
         WindowStartupLocation="CenterOwner"
         MouseDown="Window_MouseDown"
+        Closing="Window_Closing"
         Title="(WIP) grzyClothTool - Build resource"
         Background="{DynamicResource Brush50}"
         Height="450"
@@ -43,7 +44,7 @@
                     />
                 </StackPanel>
             </GroupBox>
-            
+
             <c:ModernLabelTextBox 
                 x:Name="name"
                 Label="Project name"
@@ -62,19 +63,32 @@
                 Text="{Binding BuildPath}" />
         </StackPanel>
 
+        <Grid Grid.Row="1" Margin="15,5,15,5" >
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
 
+            <ProgressBar 
+                x:Name="pbBuild" 
+                Grid.Column="0" 
+                Grid.ColumnSpan="2" 
+                HorizontalAlignment="Left"
+                Width="300"
+                Background="{DynamicResource Brush200}"
+                BorderBrush="{DynamicResource Brush100}"
+                Value="{Binding ProgressValue}"
+                Visibility="{Binding IsBuilding, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-        <Border Grid.Row="1" Padding="5">
-            <c:CustomButton 
-                HorizontalAlignment="Right"
-                x:Name="build"
-                CornerRadius="5"
-                Width="150"
-                Label="Build resource"
-                MyBtnClickEvent="build_MyBtnClickEvent"
-             />
-        </Border>
-
+            <Border Grid.Column="2" >
+                <c:CustomButton 
+                    HorizontalAlignment="Right"
+                    x:Name="build"
+                    CornerRadius="5"
+                    Width="150"
+                    Label="Build resource"
+                    MyBtnClickEvent="build_MyBtnClickEvent" />
+            </Border>
+        </Grid>
     </Grid>
-
 </Window>

--- a/grzyClothTool/Views/BuildWindow.xaml.cs
+++ b/grzyClothTool/Views/BuildWindow.xaml.cs
@@ -2,6 +2,7 @@
 using grzyClothTool.Helpers;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -15,7 +16,7 @@ namespace grzyClothTool.Views
     /// <summary>
     /// Interaction logic for BuildWindow.xaml
     /// </summary>
-    public partial class BuildWindow : Window
+    public partial class BuildWindow : Window, INotifyPropertyChanged
     {
         public enum ResourceType
         {
@@ -24,7 +25,41 @@ namespace grzyClothTool.Views
             Singleplayer
         }
 
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
         public string ProjectName { get; set; }
+
+        private bool _isBuilding;
+        public bool IsBuilding
+        {
+            get => _isBuilding;
+            set
+            {
+                if (_isBuilding != value)
+                {
+                    _isBuilding = value;
+                    OnPropertyChanged(nameof(IsBuilding));
+                }
+            }
+        }
+        private int _progressValue;
+        public int ProgressValue
+        {
+            get => _progressValue;
+            set
+            {
+                if (_progressValue != value)
+                {
+                    _progressValue = value;
+                    OnPropertyChanged(nameof(ProgressValue));
+                }
+            }
+        }
         public string BuildPath { get; set; }
 
         private ResourceType _resourceType;
@@ -40,26 +75,13 @@ namespace grzyClothTool.Views
             FocusManager.SetFocusedElement(this, this);
         }
 
-        private async void build_MyBtnClickEvent(object sender, RoutedEventArgs e)
+        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            var error = ValidateProjectName();
-            if (error != null)
-            {
-                MessageBox.Show(error);
-                return;
-            }
+            e.Cancel = IsBuilding;
+        }
 
-            if (ProjectName == null || BuildPath == null)
-            {
-                MessageBox.Show("Please fill in all fields");
-
-                CustomMessageBox.Show($"Please fill in all fields", "Error", CustomMessageBoxButtons.OKCancel);
-                return;
-            }
-            var timer = new Stopwatch();
-            timer.Start();
-            var buildHelper = new BuildResourceHelper(ProjectName, BuildPath, MainWindow.AddonManager.Addons.Count);
-
+        private async Task BuildResource(BuildResourceHelper buildHelper)
+        {
             switch (_resourceType)
             {
                 case ResourceType.FiveM:
@@ -72,14 +94,70 @@ namespace grzyClothTool.Views
                     await buildHelper.BuildSingleplayer();
                     break;
                 default:
-                    throw new NotImplementedException();
+                    throw new NotImplementedException($"Unsupported resource type: {_resourceType}");
+            }
+        }
+
+        private async void build_MyBtnClickEvent(object sender, RoutedEventArgs e)
+        {
+            var error = ValidateProjectName();
+            if (error != null)
+            {
+                MessageBox.Show(error);
+                return;
             }
 
-            Close();
-            timer.Stop();
+            if (ProjectName == null || BuildPath == null)
+            {
+                MessageBox.Show("Please fill in all fields");
+                CustomMessageBox.Show($"Please fill in all fields", "Error", CustomMessageBoxButtons.OKCancel);
+                return;
+            }
 
-            CustomMessageBox.Show($"Build done, elapsed time: {timer.Elapsed}", "Build done", CustomMessageBoxButtons.OpenFolder, BuildPath);
-            LogHelper.Log($"Build done, elapsed time: {timer.Elapsed}");
+            var buildButton = sender as CustomButton;
+            if (buildButton != null)
+            {
+                buildButton.IsEnabled = false; // blocking interactions - spamming button led to building multiple times/exception
+            }
+
+            int totalSteps = MainWindow.AddonManager.GetTotalDrawableAndTextureCount();
+
+            ProgressValue = 0;
+            pbBuild.Maximum = totalSteps;
+            IsBuilding = true;
+
+            try
+            {
+                var timer = new Stopwatch();
+
+                timer.Start();
+
+                var progress = new Progress<int>(value => ProgressValue += value);
+                var buildHelper = new BuildResourceHelper(ProjectName, BuildPath, MainWindow.AddonManager.Addons.Count, progress);
+
+                await Task.Run(() => BuildResource(buildHelper)); // moved out of ui thread, so users don't think tool stopped responding
+
+                timer.Stop();
+                CustomMessageBox.Show($"Build done, elapsed time: {timer.Elapsed}", "Build done", CustomMessageBoxButtons.OpenFolder, BuildPath);
+                LogHelper.Log($"Build done, elapsed time: {timer.Elapsed}");
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Log($"Build failed: {ex.Message}");
+                CustomMessageBox.Show($"Build failed: {ex.Message}", "Error");
+            }
+            finally
+            {
+                ProgressValue = totalSteps; // make sure that progress bar is full
+
+                if (buildButton != null)
+                {
+                    buildButton.IsEnabled = true;
+                }
+
+                IsBuilding = false;
+                Close();
+            }
         }
 
         private async Task BuildFiveMResource(BuildResourceHelper bHelper)


### PR DESCRIPTION
- restructured building method a bit
- added progress reporting 
- blocked button during build

To consider:
- check if the build path is an empty directory (?) - could prevent exceptions if someone wants to build a project in the same directory
- more accurate progress reporting - send progress after each drawable textures are copied/created