### PR TITLE
refactor: improve handling of drawables in addons

### DIFF
--- a/grzyClothTool/Controls/Drawable/DrawableList.xaml
+++ b/grzyClothTool/Controls/Drawable/DrawableList.xaml
@@ -35,10 +35,10 @@
                                     <Rectangle.Style>
                                         <Style TargetType="Rectangle">
                                             <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Sex}" Value="True">
+                                                <DataTrigger Binding="{Binding SexName}" Value="male">
                                                     <Setter Property="Fill" Value="#94c1ff"/>
                                                 </DataTrigger>
-                                                <DataTrigger Binding="{Binding Sex}" Value="False">
+                                                <DataTrigger Binding="{Binding SexName}" Value="female">
                                                     <Setter Property="Fill" Value="#ffa3c3"/>
                                                 </DataTrigger>
                                             </Style.Triggers>

--- a/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml.cs
+++ b/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml.cs
@@ -351,6 +351,7 @@ namespace grzyClothTool.Controls
                 return;
             }
 
+
             SelectedDraw.ChangeDrawableSex(newValue.ToString());
         }
 

--- a/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml.cs
+++ b/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml.cs
@@ -315,7 +315,6 @@ namespace grzyClothTool.Controls
             }
 
             SelectedDraw.ChangeDrawableType(newValue.ToString());
-            SaveHelper.SetUnsavedChanges(true);
         }
 
         private void DrawableSex_Changed(object sender, UpdatedEventArgs e)
@@ -334,7 +333,6 @@ namespace grzyClothTool.Controls
             }
 
             SelectedDraw.ChangeDrawableSex(newValue.ToString());
-            SaveHelper.SetUnsavedChanges(true);
         }
 
         private async void ReplaceReserved_Click(object sender, RoutedEventArgs e)

--- a/grzyClothTool/Enums.cs
+++ b/grzyClothTool/Enums.cs
@@ -1,75 +1,70 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace grzyClothTool;
 
-namespace grzyClothTool
+public class Enums
 {
-    public class Enums
+    public enum SexType
     {
+        female = 0,
+        male = 1
+    }
 
-        public enum Sex
-        {
-            female = 0,
-            male = 1
-        }
-        public enum ComponentNumbers
-        {
-            head = 0,
-            berd = 1,
-            hair = 2,
-            uppr = 3,
-            lowr = 4,
-            hand = 5,
-            feet = 6,
-            teef = 7,
-            accs = 8,
-            task = 9,
-            decl = 10,
-            jbib = 11
-        }
+    public enum ComponentNumbers
+    {
+        head = 0,
+        berd = 1,
+        hair = 2,
+        uppr = 3,
+        lowr = 4,
+        hand = 5,
+        feet = 6,
+        teef = 7,
+        accs = 8,
+        task = 9,
+        decl = 10,
+        jbib = 11
+    }
 
-        public enum PropNumbers
-        {
-            p_head = 0,
-            p_eyes = 1,
-            p_ears = 2,
-            p_mouth = 3,
-            p_lhand = 4,
-            p_rhand = 5,
-            p_lwrist = 6,
-            p_rwrist = 7,
-            p_hip = 8,
-            p_lfoot = 9,
-            p_rfoot = 10,
-            p_ph_l_hand = 11,
-            p_ph_r_hand = 12
-        }
+    public enum PropNumbers
+    {
+        p_head = 0,
+        p_eyes = 1,
+        p_ears = 2,
+        p_mouth = 3,
+        p_lhand = 4,
+        p_rhand = 5,
+        p_lwrist = 6,
+        p_rwrist = 7,
+        p_hip = 8,
+        p_lfoot = 9,
+        p_rfoot = 10,
+        p_ph_l_hand = 11,
+        p_ph_r_hand = 12
+    }
 
-        // https://alexguirre.github.io/rage-parser-dumps/dump.html?game=gta5&build=3179#ePedCompFlags
-        public enum DrawableFlags
-        {
-            NONE = 0,
-            BULKY = 1,
-            JOB = 2,
-            SUNNY = 4,
-            WET = 8,
-            COLD = 16,
-            NOT_IN_CAR = 32,
-            BIKE_ONLY = 64,
-            NOT_INDOORS = 128,
-            FIRE_RETARDENT = 256,
-            ARMOURED = 512,
-            LIGHTLY_ARMOURED = 1024,
-            HIGH_DETAIL = 2048,
-            DEFAULT_HELMET = 4096,
-            RANDOM_HELMET = 8192,
-            SCRIPT_HELMET = 16384,
-            FLIGHT_HELMET = 32768,
-            HIDE_IN_FIRST_PERSON = 65536,
-            USE_PHYSICS_HAT_2 = 131072,
-            PILOT_HELMET = 262144,
-            WET_MORE_WET = 524288,
-            WET_LESS_WET = 1048576,
-        }
+    // https://alexguirre.github.io/rage-parser-dumps/dump.html?game=gta5&build=3179#ePedCompFlags
+    public enum DrawableFlags
+    {
+        NONE = 0,
+        BULKY = 1,
+        JOB = 2,
+        SUNNY = 4,
+        WET = 8,
+        COLD = 16,
+        NOT_IN_CAR = 32,
+        BIKE_ONLY = 64,
+        NOT_INDOORS = 128,
+        FIRE_RETARDENT = 256,
+        ARMOURED = 512,
+        LIGHTLY_ARMOURED = 1024,
+        HIGH_DETAIL = 2048,
+        DEFAULT_HELMET = 4096,
+        RANDOM_HELMET = 8192,
+        SCRIPT_HELMET = 16384,
+        FLIGHT_HELMET = 32768,
+        HIDE_IN_FIRST_PERSON = 65536,
+        USE_PHYSICS_HAT_2 = 131072,
+        PILOT_HELMET = 262144,
+        WET_MORE_WET = 524288,
+        WET_LESS_WET = 1048576,
     }
 }

--- a/grzyClothTool/Helpers/BuildResourceHelper.cs
+++ b/grzyClothTool/Helpers/BuildResourceHelper.cs
@@ -3,7 +3,6 @@ using grzyClothTool.Models;
 using grzyClothTool.Models.Drawable;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -366,7 +365,7 @@ public class BuildResourceHelper
             SetAddon(selectedAddon);
             SetNumber(counter);
 
-            if (selectedAddon.HasMale)
+            if (selectedAddon.HasSex(true))
             {
                 var (name, bytes) = BuildMeta(true);
                 RpfFile.CreateFile(dataFolder, name, bytes);
@@ -375,7 +374,7 @@ public class BuildResourceHelper
                 await BuildSingleplayerFilesAsync(true, ymtBytes, counter, cdimages);
             }
 
-            if (selectedAddon.HasFemale)
+            if (selectedAddon.HasSex(false))
             {
                 var (name, bytes) = BuildMeta(false);
                 RpfFile.CreateFile(dataFolder, name, bytes);
@@ -404,7 +403,7 @@ public class BuildResourceHelper
         var filesToEnable = new List<string>();
         foreach (var addon in MainWindow.AddonManager.Addons)
         {
-            if (addon.HasMale)
+            if (addon.HasSex(true))
             {
                 sb.AppendLine($"    <Item>");
                 sb.AppendLine($"      <filename>dlc_{_projectName}:/common/data/mp_m_freemode_01_{_projectName}.meta</filename>");
@@ -447,7 +446,7 @@ public class BuildResourceHelper
                 }
             }
 
-            if (addon.HasFemale)
+            if (addon.HasSex(false))
             {
                 sb.AppendLine($"    <Item>");
                 sb.AppendLine($"      <filename>dlc_{_projectName}:/common/data/mp_f_freemode_01_{_projectName}.meta</filename>");

--- a/grzyClothTool/Helpers/BuildResourceHelper.cs
+++ b/grzyClothTool/Helpers/BuildResourceHelper.cs
@@ -53,19 +53,19 @@ public class BuildResourceHelper
     #region FiveM
 
 
-    public async Task BuildFiveMFilesAsync(bool isMale, byte[] ymtBytes, int counter)
+    public async Task BuildFiveMFilesAsync(Enums.SexType sex, byte[] ymtBytes, int counter)
     {
-        var pedName = GetPedName(isMale);
+        var pedName = GetPedName(sex);
         var projectName = GetProjectName(counter);
 
-        var drawables = _addon.Drawables.Where(x => x.Sex == isMale).ToList();
+        var drawables = _addon.Drawables.Where(x => x.Sex == sex).ToList();
         var drawableGroups = drawables.Select((x, i) => new { Index = i, Value = x })
                                        .GroupBy(x => x.Value.Number / GlobalConstants.MAX_DRAWABLES_IN_ADDON)
                                        .Select(x => x.Select(v => v.Value).ToList())
                                        .ToList();
 
         // Prepare all directory paths first to minimize file system access
-        var genderFolderName = isMale ? "[male]" : "[female]";
+        var genderFolderName = sex == Enums.SexType.male ? "[male]" : "[female]";
         var directoriesToEnsure = drawableGroups.SelectMany(g => g.Select(d => Path.Combine(_buildPath, "stream", genderFolderName, d.TypeName))).Distinct();
         foreach (var dir in directoriesToEnsure)
         {
@@ -153,7 +153,7 @@ public class BuildResourceHelper
         await Task.Run(() =>
             {
                 var generated = GenerateCreatureMetadata(drawables);
-                generated?.Save(_buildPath + "/stream/mp_creaturemetadata_" + GetGenderLetter(isMale) + "_" + projectName + ".ymt");
+                generated?.Save(_buildPath + "/stream/mp_creaturemetadata_" + GetGenderLetter(sex) + "_" + projectName + ".ymt");
             }
         );
     }
@@ -204,18 +204,18 @@ public class BuildResourceHelper
 
     #region AltV
 
-    public async Task BuildAltVFilesAsync(bool isMale, byte[] ymtBytes, int counter) {
-        var pedName = GetPedName(isMale);
+    public async Task BuildAltVFilesAsync(Enums.SexType sex, byte[] ymtBytes, int counter) {
+        var pedName = GetPedName(sex);
         var projectName = GetProjectName(counter);
 
-        var drawables = _addon.Drawables.Where(x => x.Sex == isMale).ToList();
+        var drawables = _addon.Drawables.Where(x => x.Sex == sex).ToList();
         var drawableGroups = drawables.Select((x, i) => new { Index = i, Value = x })
                                        .GroupBy(x => x.Value.Number / GlobalConstants.MAX_DRAWABLES_IN_ADDON)
                                        .Select(x => x.Select(v => v.Value).ToList())
                                        .ToList();
 
         // Prepare all directory paths first to minimize file system access
-        var genderFolderName = isMale ? $"{projectName}_male.rpf" : $"{projectName}_female.rpf";
+        var genderFolderName = sex == Enums.SexType.male ? $"{projectName}_male.rpf" : $"{projectName}_female.rpf";
 
         //Describe the 3 levels of a AltV clothes resource
         var firstLevelFolder = Path.Combine(_buildPath, "stream");
@@ -231,7 +231,7 @@ public class BuildResourceHelper
         string thirdLevelPropFolder = null;
         //Additionaly if props are present, create a folder for them
         if(drawables.Any(x => x.IsProp)) {
-            var genderPropFolderName = isMale ? $"{projectName}_male_p.rpf" : $"{projectName}_female_p.rpf";
+            var genderPropFolderName = sex == Enums.SexType.male ? $"{projectName}_male_p.rpf" : $"{projectName}_female_p.rpf";
 
             var secondLevelPropFolder = Path.Combine(_buildPath, "stream", genderPropFolderName);
             thirdLevelPropFolder = Path.Combine(_buildPath, "stream", genderPropFolderName, $"{pedName}_p_{projectName}");
@@ -295,7 +295,7 @@ public class BuildResourceHelper
             {
                 string creatureMetadataFolder = Path.Combine(firstLevelFolder, "creaturemetadata.rpf");
                 Directory.CreateDirectory(creatureMetadataFolder);
-                generated.Save(Path.Combine(creatureMetadataFolder, $"mp_creaturemetadata_{GetGenderLetter(isMale)}_{projectName}.ymt"));
+                generated.Save(Path.Combine(creatureMetadataFolder, $"mp_creaturemetadata_{GetGenderLetter(sex)}_{projectName}.ymt"));
             }
         });
     }
@@ -335,60 +335,7 @@ public class BuildResourceHelper
 
     #region Singleplayer
 
-    public async Task BuildSingleplayer()
-    {
-        var dlcRpf = RpfFile.CreateNew(_buildPath, "dlc.rpf", RpfEncryption.OPEN);
-        var creatureMetadatas = BuildContentXml(dlcRpf.Root);
-        BuildSetupXml(dlcRpf.Root);
-
-        var x64 = RpfFile.CreateDirectory(dlcRpf.Root, "x64");
-        var common = RpfFile.CreateDirectory(dlcRpf.Root, "common");
-        var dataFolder = RpfFile.CreateDirectory(common, "data");
-
-        var models = RpfFile.CreateDirectory(x64, "models");
-        var cdimages = RpfFile.CreateDirectory(models, "cdimages");
-
-        if(creatureMetadatas.Count > 0)
-        {
-            var animFolder = RpfFile.CreateDirectory(x64, "anim");
-            var creature = RpfFile.CreateNew(animFolder, "creaturemetadata.rpf");
-
-            foreach (var meta in creatureMetadatas)
-            {
-                RpfFile.CreateFile(creature.Root, meta.SingleplayerFileName + ".ymt", meta.Save());
-            }
-        }
-
-        int counter = 1;
-        foreach (var selectedAddon in MainWindow.AddonManager.Addons)
-        {
-            SetAddon(selectedAddon);
-            SetNumber(counter);
-
-            if (selectedAddon.HasSex(true))
-            {
-                var (name, bytes) = BuildMeta(true);
-                RpfFile.CreateFile(dataFolder, name, bytes);
-
-                var ymtBytes = BuildYMT(true);
-                await BuildSingleplayerFilesAsync(true, ymtBytes, counter, cdimages);
-            }
-
-            if (selectedAddon.HasSex(false))
-            {
-                var (name, bytes) = BuildMeta(false);
-                RpfFile.CreateFile(dataFolder, name, bytes);
-
-                var ymtBytes = BuildYMT(false);
-                await BuildSingleplayerFilesAsync(false, ymtBytes, counter, cdimages);
-            }
-
-            _progress.Report(selectedAddon.GetTotalDrawableAndTextureCount());
-            counter++;
-        }
-    }
-
-    private List<RbfFile> BuildContentXml(RpfDirectoryEntry dir)
+    public List<RbfFile> BuildContentXml(RpfDirectoryEntry dir)
     {
         StringBuilder sb = new();
 
@@ -403,7 +350,7 @@ public class BuildResourceHelper
         var filesToEnable = new List<string>();
         foreach (var addon in MainWindow.AddonManager.Addons)
         {
-            if (addon.HasSex(true))
+            if (addon.HasSex(Enums.SexType.male))
             {
                 sb.AppendLine($"    <Item>");
                 sb.AppendLine($"      <filename>dlc_{_projectName}:/common/data/mp_m_freemode_01_{_projectName}.meta</filename>");
@@ -437,7 +384,7 @@ public class BuildResourceHelper
                     filesToEnable.Add($"dlc_{_projectName}:/%PLATFORM%/models/cdimages/{_projectName}_male_p.rpf");
                 }
 
-                var drawables = addon.Drawables.Where(x => x.Sex == true).ToList();
+                var drawables = addon.Drawables.Where(x => x.Sex == Enums.SexType.male).ToList();
                 var generated = GenerateCreatureMetadata(drawables);
                 if (generated != null)
                 {
@@ -446,7 +393,7 @@ public class BuildResourceHelper
                 }
             }
 
-            if (addon.HasSex(false))
+            if (addon.HasSex(Enums.SexType.female))
             {
                 sb.AppendLine($"    <Item>");
                 sb.AppendLine($"      <filename>dlc_{_projectName}:/common/data/mp_f_freemode_01_{_projectName}.meta</filename>");
@@ -481,7 +428,7 @@ public class BuildResourceHelper
                     filesToEnable.Add($"dlc_{_projectName}:/%PLATFORM%/models/cdimages/{_projectName}_female_p.rpf");
                 }
 
-                var drawables = addon.Drawables.Where(x => x.Sex == false).ToList();
+                var drawables = addon.Drawables.Where(x => x.Sex == Enums.SexType.female).ToList();
                 var generated = GenerateCreatureMetadata(drawables);
                 if (generated != null)
                 {
@@ -534,7 +481,7 @@ public class BuildResourceHelper
         return generatedCreatureMetadatas;
     }
 
-    private void BuildSetupXml(RpfDirectoryEntry dir)
+    public void BuildSetupXml(RpfDirectoryEntry dir)
     {
         var timestamp = DateTimeOffset.UtcNow.ToString("dd/MM/yyyy HH:mm:ss");
 
@@ -568,12 +515,12 @@ public class BuildResourceHelper
         RpfFile.CreateFile(dir, "setup2.xml", Encoding.UTF8.GetBytes(sb.ToString()));
     }
 
-    private async Task BuildSingleplayerFilesAsync(bool isMale, byte[] ymtBytes, int counter, RpfDirectoryEntry cdimages)
+    public async Task BuildSingleplayerFilesAsync(Enums.SexType sex, byte[] ymtBytes, int counter, RpfDirectoryEntry cdimages)
     {
-        var pedName = GetPedName(isMale);
+        var pedName = GetPedName(sex);
         var projectName = GetProjectName(counter);
 
-        var drawables = _addon.Drawables.Where(x => x.Sex == isMale).ToList();
+        var drawables = _addon.Drawables.Where(x => x.Sex == Enums.SexType.male).ToList();
         var drawableGroups = drawables.Select((x, i) => new { Index = i, Value = x })
                                        .GroupBy(x => x.Value.Number / GlobalConstants.MAX_DRAWABLES_IN_ADDON)
                                        .Select(x => x.Select(v => v.Value).ToList())
@@ -583,7 +530,7 @@ public class BuildResourceHelper
 
         var hasProps = drawables.Any(x => x.IsProp);
 
-        var genderRpfName = isMale ? "_male" : "_female";
+        var genderRpfName = sex == Enums.SexType.male ? "_male" : "_female";
         var componentsRpf = RpfFile.CreateNew(cdimages, projectName + genderRpfName + ".rpf");
         var componentsFolder = RpfFile.CreateDirectory(componentsRpf.Root, pedName + "_" + projectName);
         RpfFile propsRpf = null;
@@ -630,7 +577,7 @@ public class BuildResourceHelper
 
     #region Generic
 
-    public byte[] BuildYMT(bool isMale)
+    public byte[] BuildYMT(Enums.SexType sex)
     {
         var mb = new MetaBuilder();
         var mdb = mb.EnsureBlock(MetaName.CPedVariationInfo);
@@ -647,7 +594,7 @@ public class BuildResourceHelper
         availComp.SetBytes(generatedAvailComp);
         CPed.availComp = availComp;
 
-        var allDrawables = _addon.Drawables.Where(x => x.Sex == isMale).ToList();
+        var allDrawables = _addon.Drawables.Where(x => x.Sex == sex).ToList();
         var allCompDrawablesArray = allDrawables.Where(x => !x.IsProp).ToArray();
         var allPropDrawablesArray = allDrawables.Where(x => x.IsProp).ToArray();
 
@@ -782,11 +729,11 @@ public class BuildResourceHelper
         return data;
     }
 
-    public (string, byte[]) BuildMeta(bool isMale)
+    public (string, byte[]) BuildMeta(Enums.SexType sex)
     {
-        var eCharacter = isMale ? "SCR_CHAR_MULTIPLAYER" : "SCR_CHAR_MULTIPLAYER_F";
-        var genderLetter = GetGenderLetter(isMale);
-        var pedName = GetPedName(isMale);
+        var eCharacter = sex == Enums.SexType.male ? "SCR_CHAR_MULTIPLAYER" : "SCR_CHAR_MULTIPLAYER_F";
+        var genderLetter = GetGenderLetter(sex);
+        var pedName = GetPedName(sex);
         var projectName = GetProjectName();
 
         StringBuilder sb = new();
@@ -909,14 +856,24 @@ public class BuildResourceHelper
         return string.Concat(input.Split(Path.GetInvalidFileNameChars()));
     }
 
-    private static string GetGenderLetter(bool isMale)
+    private static string GetGenderLetter(Enums.SexType sex)
     {
-        return isMale ? "m" : "f";
+        return sex switch
+        {
+            Enums.SexType.male => "m",
+            Enums.SexType.female => "f",
+            _ => throw new ArgumentOutOfRangeException(nameof(sex), sex, "Wrong sexType GetGenderLetter")
+        };
     }
 
-    private static string GetPedName(bool isMale)
+    private static string GetPedName(Enums.SexType sex)
     {
-        return isMale ? "mp_m_freemode_01" : "mp_f_freemode_01";
+        return sex switch
+        {
+            Enums.SexType.male => "mp_m_freemode_01",
+            Enums.SexType.female => "mp_f_freemode_01",
+            _ => throw new ArgumentOutOfRangeException(nameof(sex), sex, "Wrong sexType GetPedName")
+        };
     }
 
     #endregion

--- a/grzyClothTool/Helpers/EnumHelper.cs
+++ b/grzyClothTool/Helpers/EnumHelper.cs
@@ -13,11 +13,6 @@ public static class EnumHelper
         return Enum.GetName(enumType, type);
     }
 
-    public static string GetSex(bool isMale)
-    {
-        return Enum.GetName(typeof(Enums.Sex), isMale ? 1 : 0);
-    }
-
     public static int GetValue(string type, bool isProp)
     {
         Type enumType = isProp ? typeof(Enums.PropNumbers) : typeof(Enums.ComponentNumbers);
@@ -171,8 +166,8 @@ public static class EnumHelper
 
     public static List<string> GetSexTypeList()
     {
-        return Enum.GetValues(typeof(Sex))
-            .Cast<Sex>()
+        return Enum.GetValues(typeof(SexType))
+            .Cast<SexType>()
             .Select(item => item.ToString())
             .ToList();
     }

--- a/grzyClothTool/Helpers/FileHelper.cs
+++ b/grzyClothTool/Helpers/FileHelper.cs
@@ -46,7 +46,7 @@ public static class FileHelper
         }
     }
 
-    public static Task<GDrawable> CreateDrawableAsync(string filePath, bool isMale, bool isProp, int typeNumber, int countOfType)
+    public static Task<GDrawable> CreateDrawableAsync(string filePath, Enums.SexType sex, bool isProp, int typeNumber, int countOfType)
     {
         var name = EnumHelper.GetName(typeNumber, isProp);
 
@@ -59,7 +59,7 @@ public static class FileHelper
         // Should we inform user, that they tried to add too many textures?
         var textures = new ObservableCollection<GTexture>(matchingTextures.Select((path, txtNumber) => new GTexture(path, typeNumber, countOfType, txtNumber, drawableHasSkin, isProp)).Take(GlobalConstants.MAX_DRAWABLE_TEXTURES));
 
-        return Task.FromResult(new GDrawable(filePath, isMale, isProp, typeNumber, countOfType, drawableHasSkin, textures));
+        return Task.FromResult(new GDrawable(filePath, sex, isProp, typeNumber, countOfType, drawableHasSkin, textures));
     }
 
     public static async Task CopyAsync(string sourcePath, string destinationPath)

--- a/grzyClothTool/Models/Addon.cs
+++ b/grzyClothTool/Models/Addon.cs
@@ -79,8 +79,9 @@ public class Addon : INotifyPropertyChanged
         {
             for (int i = 1; i < 50; i++)
             {
+                var sexEnum = i % 2 == 0 ? Enums.SexType.female : Enums.SexType.male;
                 Drawables.Add(
-                    new GDrawable("grzyClothTool/Assets/jbib_000_u.ydd", i % 2 == 0, false, 11, i, false,
+                    new GDrawable("grzyClothTool/Assets/jbib_000_u.ydd", sexEnum, false, 11, i, false,
                     [
                         new("grzyClothTool/Assets/jbib_diff_000_a_uni.ytd", 11, 0, 0, false, false), 
                         new("grzyClothTool/Assets/jbib_diff_000_a_uni.ytd", 11, 0, 1, false, false)
@@ -92,7 +93,7 @@ public class Addon : INotifyPropertyChanged
         }
     }
 
-    public int GetNextDrawableNumber(int typeNumeric, bool isProp, bool isMale)
+    public int GetNextDrawableNumber(int typeNumeric, bool isProp, Enums.SexType sex)
     {
         var nextNumber = 0;
         var currentAddonIndex = 0;
@@ -100,7 +101,7 @@ public class Addon : INotifyPropertyChanged
         while (currentAddonIndex < MainWindow.AddonManager.Addons.Count)
         {
             var currentAddon = MainWindow.AddonManager.Addons[currentAddonIndex];
-            var countOfType = currentAddon.Drawables.Count(x => x.TypeNumeric == typeNumeric && x.IsProp == isProp && x.Sex == isMale);
+            var countOfType = currentAddon.Drawables.Count(x => x.TypeNumeric == typeNumeric && x.IsProp == isProp && x.Sex == sex);
 
             // If the number of drawables of this type has reached 128, move to the next addon
             if (countOfType >= GlobalConstants.MAX_DRAWABLES_IN_ADDON)
@@ -116,9 +117,9 @@ public class Addon : INotifyPropertyChanged
         return nextNumber;
     }
 
-    public bool HasSex(bool isMale)
+    public bool HasSex(Enums.SexType sex)
     {
-        return Drawables.Any(x => x.Sex == isMale);
+        return Drawables.Any(x => x.Sex == sex);
     }
 
     public int GetTotalDrawableAndTextureCount()

--- a/grzyClothTool/Models/Addon.cs
+++ b/grzyClothTool/Models/Addon.cs
@@ -13,10 +13,16 @@ public class Addon : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler PropertyChanged;
 
-    public string Name { get; set; }
-
-    public bool HasFemale { get; set; }
-    public bool HasMale { get; set; }
+    private string _name;
+    public string Name
+    {
+        get { return _name; }
+        set 
+        {
+            _name = value; 
+            OnPropertyChanged(); 
+        }
+    }
     public bool HasProps { get; set; }
 
     [JsonIgnore]
@@ -108,6 +114,11 @@ public class Addon : INotifyPropertyChanged
         }
 
         return nextNumber;
+    }
+
+    public bool HasSex(bool isMale)
+    {
+        return Drawables.Any(x => x.Sex == isMale);
     }
 
     public int GetTotalDrawableAndTextureCount()

--- a/grzyClothTool/Models/AddonManager.cs
+++ b/grzyClothTool/Models/AddonManager.cs
@@ -94,10 +94,10 @@ namespace grzyClothTool.Models
             var addonName = Path.GetFileNameWithoutExtension(path);
 
             // Determine if the addonName indicates male or female
-            bool isMale = addonName.Contains("mp_m_freemode_01");
+            Enums.SexType sex = addonName.Contains("mp_m_freemode_01") ? Enums.SexType.male : Enums.SexType.female;
 
             // Build the appropriate regex pattern based on whether it's male or female
-            string genderSpecificPart = isMale ? "mp_m_freemode_01" : "mp_f_freemode_01";
+            string genderSpecificPart = sex == Enums.SexType.male ? "mp_m_freemode_01" : "mp_f_freemode_01";
             string pattern = $@"^{genderSpecificPart}(_p)?.*?\^";
 
             var yddFiles = Directory.GetFiles(dirPath, "*.ydd", SearchOption.AllDirectories)
@@ -152,7 +152,7 @@ namespace grzyClothTool.Models
             //merge ydd with yld files
             var mergedFiles = yddFiles.Concat(yldFiles).ToArray();
 
-            await AddDrawables(mergedFiles, isMale);
+            await AddDrawables(mergedFiles, sex);
 
             foreach (var addon in Addons)
             {
@@ -197,7 +197,7 @@ namespace grzyClothTool.Models
             }
         }
 
-        public async Task AddDrawables(string[] filePaths, bool isMale)
+        public async Task AddDrawables(string[] filePaths, Enums.SexType sex)
         {
             Regex alternateRegex = new(@"_\w_\d+\.ydd$");
             Regex physicsRegex = new(@"\.yld$");
@@ -219,7 +219,7 @@ namespace grzyClothTool.Models
                 Addon currentAddon = Addons[currentAddonIndex];
 
                 // Calculate countOfType for the current Addon
-                var drawablesOfType = currentAddon.Drawables.Where(x => x.TypeNumeric == drawableType && x.IsProp == isProp && x.Sex == isMale);
+                var drawablesOfType = currentAddon.Drawables.Where(x => x.TypeNumeric == drawableType && x.IsProp == isProp && x.Sex == sex);
                 var countOfType = drawablesOfType.Count();
 
                 if (alternateRegex.IsMatch(filePath))
@@ -240,7 +240,7 @@ namespace grzyClothTool.Models
                     continue;
                 }
 
-                var drawable = await Task.Run(() => FileHelper.CreateDrawableAsync(filePath, isMale, isProp, drawableType, countOfType));
+                var drawable = await Task.Run(() => FileHelper.CreateDrawableAsync(filePath, sex, isProp, drawableType, countOfType));
 
                 // Check if the number of drawables of this type has reached 128
                 while (countOfType >= GlobalConstants.MAX_DRAWABLES_IN_ADDON)
@@ -260,7 +260,7 @@ namespace grzyClothTool.Models
                     }
 
                     // Calculate countOfType for the current Addon
-                    countOfType = currentAddon.Drawables.Count(x => x.TypeNumeric == drawableType && x.IsProp == isProp && x.Sex == isMale);
+                    countOfType = currentAddon.Drawables.Count(x => x.TypeNumeric == drawableType && x.IsProp == isProp && x.Sex == sex);
 
                     // Update name and number
                     drawable.Number = countOfType;

--- a/grzyClothTool/Models/Drawable/GDrawable.cs
+++ b/grzyClothTool/Models/Drawable/GDrawable.cs
@@ -303,18 +303,14 @@ public class GDrawable : INotifyPropertyChanged
         var reserved = new GDrawableReserved(Sex, IsProp, TypeNumeric, Number);
         var index = MainWindow.AddonManager.SelectedAddon.Drawables.IndexOf(this);
 
-        // change current drawable to new type
-        Number = MainWindow.AddonManager.SelectedAddon.GetNextDrawableNumber(newTypeNumeric, IsProp, Sex);
+        // change drawable to new type
         TypeNumeric = newTypeNumeric;
-        SetDrawableName();
-
-        // add new drawable with new number and type
-        MainWindow.AddonManager.SelectedAddon.Drawables.Insert(index + 1, this);
 
         // replace drawable with reserved in the same place
         MainWindow.AddonManager.SelectedAddon.Drawables[index] = reserved;
 
-        MainWindow.AddonManager.SelectedAddon.Drawables.Sort();
+        // re-add changed drawable
+        MainWindow.AddonManager.AddDrawable(this);
     }
 
     public void ChangeDrawableSex(string newSex)
@@ -324,23 +320,14 @@ public class GDrawable : INotifyPropertyChanged
         var reserved = new GDrawableReserved(Sex, IsProp, TypeNumeric, Number);
         var index = MainWindow.AddonManager.SelectedAddon.Drawables.IndexOf(this);
     
-        // adjust drawable number and change sex
-        Number = MainWindow.AddonManager.SelectedAddon.GetNextDrawableNumber(TypeNumeric, IsProp, isMale);
+        // change drawable sex
         Sex = isMale;
-
-        SetDrawableName();
-
-        // add new drawable with new number and sex
-        MainWindow.AddonManager.SelectedAddon.Drawables.Add(this);
 
         // replace drawable with reserved in the same place
         MainWindow.AddonManager.SelectedAddon.Drawables[index] = reserved;
 
-        MainWindow.AddonManager.SelectedAddon.Drawables.Sort();
-
-        // This might not be needed - adding just in case someone is bulk-adding clothes, without specifying the sex
-        if (isMale && !MainWindow.AddonManager.SelectedAddon.HasMale) MainWindow.AddonManager.SelectedAddon.HasMale = true;
-        if (!isMale && !MainWindow.AddonManager.SelectedAddon.HasFemale) MainWindow.AddonManager.SelectedAddon.HasFemale = true;
+        // re-add changed drawable
+        MainWindow.AddonManager.AddDrawable(this);
     }
 
     protected void OnPropertyChanged([CallerMemberName] string? name = null)

--- a/grzyClothTool/Models/Drawable/GDrawable.cs
+++ b/grzyClothTool/Models/Drawable/GDrawable.cs
@@ -15,6 +15,8 @@ using System;
 using grzyClothTool.Controls;
 using System.Runtime.Serialization;
 using grzyClothTool.Models.Texture;
+using static grzyClothTool.Enums;
+using System.Drawing.Drawing2D;
 
 namespace grzyClothTool.Models.Drawable;
 #nullable enable
@@ -79,12 +81,12 @@ public class GDrawable : INotifyPropertyChanged
     {
         get
         {
-            _sexName ??= EnumHelper.GetSex(Sex);
-            return _sexName;
+            return _sexName ??= Enum.GetName(Sex)!;
         }
         set
         {
             _sexName = value;
+            OnPropertyChanged();
         }
     }
 
@@ -97,8 +99,19 @@ public class GDrawable : INotifyPropertyChanged
     /// <returns>
     /// true(1) = male ped, false(0) = female ped
     /// </returns>
-    private bool _sex;
-    public bool Sex
+    private bool _sexx;
+    public bool Sexx
+    {
+        get => _sexx;
+        set
+        {
+            _sexx = value;
+            OnPropertyChanged();
+        }
+    }
+
+    private Enums.SexType _sex;
+    public Enums.SexType Sex
     {
         get => _sex;
         set
@@ -227,7 +240,7 @@ public class GDrawable : INotifyPropertyChanged
 
     public ObservableCollection<Texture.GTexture> Textures { get; set; }
 
-    public GDrawable(string drawablePath, bool isMale, bool isProp, int compType, int count, bool hasSkin, ObservableCollection<GTexture> textures)
+    public GDrawable(string drawablePath, Enums.SexType sex, bool isProp, int compType, int count, bool hasSkin, ObservableCollection<GTexture> textures)
     {
         IsLoading = true;
 
@@ -236,7 +249,7 @@ public class GDrawable : INotifyPropertyChanged
         TypeNumeric = compType;
         Number = count;
         HasSkin = hasSkin;
-        Sex = isMale;
+        Sex = sex;
         IsProp = isProp;
         IsNew = true;
 
@@ -281,7 +294,7 @@ public class GDrawable : INotifyPropertyChanged
         SetDrawableName();
     }
 
-    protected GDrawable(bool isMale, bool isProp, int compType, int count) { /* Used in GReservedDrawable */ }
+    protected GDrawable(Enums.SexType sex, bool isProp, int compType, int count) { /* Used in GReservedDrawable */ }
 
     public void SetDrawableName()
     {
@@ -315,13 +328,13 @@ public class GDrawable : INotifyPropertyChanged
 
     public void ChangeDrawableSex(string newSex)
     {
-        // transform new sex to bool
-        var isMale = newSex == "male";
+        // transform new sex to enum
+        var newSexEnum = Enum.Parse<Enums.SexType>(newSex);
         var reserved = new GDrawableReserved(Sex, IsProp, TypeNumeric, Number);
         var index = MainWindow.AddonManager.SelectedAddon.Drawables.IndexOf(this);
     
         // change drawable sex
-        Sex = isMale;
+        Sex = newSexEnum;
 
         // replace drawable with reserved in the same place
         MainWindow.AddonManager.SelectedAddon.Drawables[index] = reserved;

--- a/grzyClothTool/Models/Drawable/GDrawable.cs
+++ b/grzyClothTool/Models/Drawable/GDrawable.cs
@@ -1,6 +1,4 @@
-﻿using grzyClothTool.Extensions;
-using grzyClothTool.Helpers;
-using grzyClothTool.Views;
+﻿using grzyClothTool.Helpers;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -15,8 +13,6 @@ using System;
 using grzyClothTool.Controls;
 using System.Runtime.Serialization;
 using grzyClothTool.Models.Texture;
-using static grzyClothTool.Enums;
-using System.Drawing.Drawing2D;
 
 namespace grzyClothTool.Models.Drawable;
 #nullable enable
@@ -95,20 +91,6 @@ public class GDrawable : INotifyPropertyChanged
 
     [JsonIgnore]
     public static List<string> AvailableSex => EnumHelper.GetSexTypeList();
-
-    /// <returns>
-    /// true(1) = male ped, false(0) = female ped
-    /// </returns>
-    private bool _sexx;
-    public bool Sexx
-    {
-        get => _sexx;
-        set
-        {
-            _sexx = value;
-            OnPropertyChanged();
-        }
-    }
 
     private Enums.SexType _sex;
     public Enums.SexType Sex

--- a/grzyClothTool/Models/Drawable/GDrawableReserved.cs
+++ b/grzyClothTool/Models/Drawable/GDrawableReserved.cs
@@ -8,13 +8,13 @@ public class GDrawableReserved : GDrawable
 {
     public override bool IsReserved => true;
 
-    public GDrawableReserved(bool isMale, bool isProp, int compType, int count) : base(isMale, isProp, compType, count)
+    public GDrawableReserved(Enums.SexType sex, bool isProp, int compType, int count) : base(sex, isProp, compType, count)
     {
         FilePath = Path.Combine(FileHelper.ReservedAssetsPath, "reservedDrawable.ydd");
         Textures = [new GTexture(Path.Combine(FileHelper.ReservedAssetsPath, "reservedTexture.ytd"), compType, count, 0, false, isProp)];
         TypeNumeric = compType;
         Number = count;
-        Sex = isMale;
+        Sex = sex;
         IsProp = isProp;
 
         SetDrawableName();

--- a/grzyClothTool/Views/BuildWindow.xaml.cs
+++ b/grzyClothTool/Views/BuildWindow.xaml.cs
@@ -1,5 +1,7 @@
-﻿using grzyClothTool.Controls;
+﻿using CodeWalker.GameFiles;
+using grzyClothTool.Controls;
 using grzyClothTool.Helpers;
+using grzyClothTool.Models;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -91,7 +93,7 @@ namespace grzyClothTool.Views
                     await BuildAltVResource(buildHelper);
                     break;
                 case ResourceType.Singleplayer:
-                    await buildHelper.BuildSingleplayer();
+                    await BuildSingleplayerResource(buildHelper);
                     break;
                 default:
                     throw new NotImplementedException($"Unsupported resource type: {_resourceType}");
@@ -160,79 +162,120 @@ namespace grzyClothTool.Views
             }
         }
 
+        private void AddBuildTasksForSex(BuildResourceHelper bHelper, Addon selectedAddon, Enums.SexType sexType, List<Task> tasks, List<string> metaFiles, int counter, RpfDirectoryEntry cdimages = null, RpfDirectoryEntry dataFolder = null)
+        {
+            if (selectedAddon.HasSex(sexType))
+            {
+                var bytes = bHelper.BuildYMT(sexType);
+                if (_resourceType == ResourceType.FiveM)
+                {
+                    tasks.Add(bHelper.BuildFiveMFilesAsync(sexType, bytes, counter));
+                }
+                else if (_resourceType == ResourceType.AltV)
+                {
+                    tasks.Add(bHelper.BuildAltVFilesAsync(sexType, bytes, counter));
+                }
+                else if (_resourceType == ResourceType.Singleplayer)
+                {
+                    var (name, metaBytes) = bHelper.BuildMeta(sexType);
+                    RpfFile.CreateFile(dataFolder, name, metaBytes);
+                    tasks.Add(bHelper.BuildSingleplayerFilesAsync(sexType, bytes, counter, cdimages));
+                }
+
+                if (_resourceType != ResourceType.Singleplayer)
+                {
+                    var (metaName, metaContent) = bHelper.BuildMeta(sexType);
+                    metaFiles.Add(metaName);
+
+                    var path = _resourceType == ResourceType.FiveM ? Path.Combine(BuildPath, metaName) : Path.Combine(BuildPath, "stream", metaName);
+                    tasks.Add(File.WriteAllBytesAsync(path, metaContent));
+                }
+            }
+        }
+
         private async Task BuildFiveMResource(BuildResourceHelper bHelper)
         {
             int counter = 1;
             var metaFiles = new List<string>();
             var tasks = new List<Task>();
-            
+
             foreach (var selectedAddon in MainWindow.AddonManager.Addons)
             {
                 bHelper.SetAddon(selectedAddon);
                 bHelper.SetNumber(counter);
 
-                if (selectedAddon.HasSex(true))
-                {
-                    var bytes = bHelper.BuildYMT(true);
-                    tasks.Add(bHelper.BuildFiveMFilesAsync(true, bytes, counter));
+                AddBuildTasksForSex(bHelper, selectedAddon, Enums.SexType.male, tasks, metaFiles, counter);
+                AddBuildTasksForSex(bHelper, selectedAddon, Enums.SexType.female, tasks, metaFiles, counter);
 
-                    var (name, b) = bHelper.BuildMeta(true);
-                    metaFiles.Add(name);
-
-                    var path = Path.Combine(BuildPath, name);
-                    tasks.Add(File.WriteAllBytesAsync(path, b));
-                }
-                if (selectedAddon.HasSex(false))
-                {
-                    var bytes = bHelper.BuildYMT(false);
-                    tasks.Add(bHelper.BuildFiveMFilesAsync(false, bytes, counter));
-
-                    var (name, b) = bHelper.BuildMeta(false);
-                    metaFiles.Add(name);
-
-                    var path = Path.Combine(BuildPath, name);
-                    tasks.Add(File.WriteAllBytesAsync(path, b));
-                }
                 counter++;
             }
+
             await Task.WhenAll(tasks);
             bHelper.BuildFirstPersonAlternatesMeta();
             bHelper.BuildFxManifest(metaFiles);
         }
 
-        private async Task BuildAltVResource(BuildResourceHelper bHelper) {
+        private async Task BuildAltVResource(BuildResourceHelper bHelper)
+        {
             int counter = 1;
             var metaFiles = new List<string>();
             var tasks = new List<Task>();
 
-            foreach(var selectedAddon in MainWindow.AddonManager.Addons) {
+            foreach (var selectedAddon in MainWindow.AddonManager.Addons)
+            {
                 bHelper.SetAddon(selectedAddon);
                 bHelper.SetNumber(counter);
 
-                if(selectedAddon.HasSex(true)) {
-                    var bytes = bHelper.BuildYMT(true);
-                    tasks.Add(bHelper.BuildAltVFilesAsync(true, bytes, counter));
+                AddBuildTasksForSex(bHelper, selectedAddon, Enums.SexType.male, tasks, metaFiles, counter);
+                AddBuildTasksForSex(bHelper, selectedAddon, Enums.SexType.female, tasks, metaFiles, counter);
 
-                    var (name, b) = bHelper.BuildMeta(true);
-                    metaFiles.Add(name);
-
-                    var path = Path.Combine(BuildPath, "stream", name);
-                    tasks.Add(File.WriteAllBytesAsync(path, b));
-                }
-                if(selectedAddon.HasSex(false)) {
-                    var bytes = bHelper.BuildYMT(false);
-                    tasks.Add(bHelper.BuildAltVFilesAsync(false, bytes, counter));
-
-                    var (name, b) = bHelper.BuildMeta(false);
-                    metaFiles.Add(name);
-
-                    var path = Path.Combine(BuildPath, "stream", name);
-                    tasks.Add(File.WriteAllBytesAsync(path, b));
-                }
                 counter++;
             }
+
             await Task.WhenAll(tasks);
             bHelper.BuildAltVTomls(metaFiles);
+        }
+
+        private async Task BuildSingleplayerResource(BuildResourceHelper bHelper)
+        {
+            var dlcRpf = RpfFile.CreateNew(BuildPath, "dlc.rpf", RpfEncryption.OPEN);
+            var creatureMetadatas = bHelper.BuildContentXml(dlcRpf.Root);
+            bHelper.BuildSetupXml(dlcRpf.Root);
+
+            var x64 = RpfFile.CreateDirectory(dlcRpf.Root, "x64");
+            var common = RpfFile.CreateDirectory(dlcRpf.Root, "common");
+            var dataFolder = RpfFile.CreateDirectory(common, "data");
+
+            var models = RpfFile.CreateDirectory(x64, "models");
+            var cdimages = RpfFile.CreateDirectory(models, "cdimages");
+
+            if (creatureMetadatas.Count > 0)
+            {
+                var animFolder = RpfFile.CreateDirectory(x64, "anim");
+                var creature = RpfFile.CreateNew(animFolder, "creaturemetadata.rpf");
+
+                foreach (var meta in creatureMetadatas)
+                {
+                    RpfFile.CreateFile(creature.Root, meta.SingleplayerFileName + ".ymt", meta.Save());
+                }
+            }
+
+            int counter = 1;
+            var tasks = new List<Task>();
+            var metaFiles = new List<string>();
+
+            foreach (var selectedAddon in MainWindow.AddonManager.Addons)
+            {
+                bHelper.SetAddon(selectedAddon);
+                bHelper.SetNumber(counter);
+
+                AddBuildTasksForSex(bHelper, selectedAddon, Enums.SexType.male, tasks, metaFiles, counter, cdimages, dataFolder);
+                AddBuildTasksForSex(bHelper, selectedAddon, Enums.SexType.female, tasks, metaFiles, counter, cdimages, dataFolder);
+
+                counter++;
+            }
+
+            await Task.WhenAll(tasks);
         }
 
         private void RadioButton_ChangedEvent(object sender, RoutedEventArgs e)

--- a/grzyClothTool/Views/BuildWindow.xaml.cs
+++ b/grzyClothTool/Views/BuildWindow.xaml.cs
@@ -171,7 +171,7 @@ namespace grzyClothTool.Views
                 bHelper.SetAddon(selectedAddon);
                 bHelper.SetNumber(counter);
 
-                if (selectedAddon.HasMale)
+                if (selectedAddon.HasSex(true))
                 {
                     var bytes = bHelper.BuildYMT(true);
                     tasks.Add(bHelper.BuildFiveMFilesAsync(true, bytes, counter));
@@ -182,7 +182,7 @@ namespace grzyClothTool.Views
                     var path = Path.Combine(BuildPath, name);
                     tasks.Add(File.WriteAllBytesAsync(path, b));
                 }
-                if (selectedAddon.HasFemale)
+                if (selectedAddon.HasSex(false))
                 {
                     var bytes = bHelper.BuildYMT(false);
                     tasks.Add(bHelper.BuildFiveMFilesAsync(false, bytes, counter));
@@ -209,7 +209,7 @@ namespace grzyClothTool.Views
                 bHelper.SetAddon(selectedAddon);
                 bHelper.SetNumber(counter);
 
-                if(selectedAddon.HasMale) {
+                if(selectedAddon.HasSex(true)) {
                     var bytes = bHelper.BuildYMT(true);
                     tasks.Add(bHelper.BuildAltVFilesAsync(true, bytes, counter));
 
@@ -219,7 +219,7 @@ namespace grzyClothTool.Views
                     var path = Path.Combine(BuildPath, "stream", name);
                     tasks.Add(File.WriteAllBytesAsync(path, b));
                 }
-                if(selectedAddon.HasFemale) {
+                if(selectedAddon.HasSex(false)) {
                     var bytes = bHelper.BuildYMT(false);
                     tasks.Add(bHelper.BuildAltVFilesAsync(false, bytes, counter));
 

--- a/grzyClothTool/Views/ProjectWindow.xaml.cs
+++ b/grzyClothTool/Views/ProjectWindow.xaml.cs
@@ -31,7 +31,7 @@ namespace grzyClothTool.Views
     /// </summary>
     public partial class ProjectWindow : UserControl, INotifyPropertyChanged
     {
-        private bool PrevDrawableSex;
+        private Enums.SexType PrevDrawableSex;
         public event PropertyChangedEventHandler PropertyChanged;
 
         private Addon _addon;
@@ -66,7 +66,7 @@ namespace grzyClothTool.Views
         private async void Add_DrawableFile(object sender, RoutedEventArgs e)
         {
             var btn = sender as CustomButton;
-            var isMaleBtn = btn.Label.ToString().Equals("male", StringComparison.CurrentCultureIgnoreCase);
+            var sexBtn = btn.Label.ToString().Equals("male", StringComparison.CurrentCultureIgnoreCase) ? Enums.SexType.male : Enums.SexType.female;
             e.Handled = true;
 
             OpenFileDialog files = new()
@@ -82,7 +82,7 @@ namespace grzyClothTool.Views
                 var timer = new Stopwatch();
                 timer.Start();
 
-                await MainWindow.AddonManager.AddDrawables(files.FileNames, isMaleBtn);
+                await MainWindow.AddonManager.AddDrawables(files.FileNames, sexBtn);
 
                 timer.Stop();
                 LogHelper.Log($"Added drawables in {timer.Elapsed}");
@@ -94,7 +94,7 @@ namespace grzyClothTool.Views
         private async void Add_DrawableFolder(object sender, RoutedEventArgs e)
         {
             var btn = sender as CustomButton;
-            var isMaleBtn = btn.Tag.ToString().Equals("male", StringComparison.CurrentCultureIgnoreCase);
+            var sexBtn = btn.Tag.ToString().Equals("male", StringComparison.CurrentCultureIgnoreCase) ? Enums.SexType.male : Enums.SexType.female;
             e.Handled = true;
 
             OpenFolderDialog folder = new()
@@ -111,7 +111,7 @@ namespace grzyClothTool.Views
                 foreach (var fldr in folder.FolderNames)
                 {
                     var files = Directory.GetFiles(fldr, "*.ydd", SearchOption.AllDirectories).OrderBy(f => Path.GetFileName(f)).ToArray();
-                    await MainWindow.AddonManager.AddDrawables(files, isMaleBtn);
+                    await MainWindow.AddonManager.AddDrawables(files, sexBtn);
                 }
 
                 timer.Stop();
@@ -285,7 +285,7 @@ namespace grzyClothTool.Views
                 PrevDrawableSex = Addon.SelectedDrawable.Sex;
 
                 updateName = "GenderChanged";
-                value = Addon.SelectedDrawable.Sex ? "mp_m_freemode_01" : "mp_f_freemode_01";
+                value = Addon.SelectedDrawable.Sex == Enums.SexType.male ? "mp_m_freemode_01" : "mp_f_freemode_01";
                 updateDict.Add(updateName, value);
             }
 

--- a/grzyClothTool/Views/ProjectWindow.xaml.cs
+++ b/grzyClothTool/Views/ProjectWindow.xaml.cs
@@ -132,7 +132,7 @@ namespace grzyClothTool.Views
             {
                 case ModifierKeys.Shift:
                     // Shift+Delete was pressed, delete the drawable instantly
-                    DeleteDrawable(Addon.SelectedDrawable);
+                    MainWindow.AddonManager.DeleteDrawable(Addon.SelectedDrawable);
                     break;
                 case ModifierKeys.Control:
                     // Ctrl+Delete was pressed, replace the drawable instantly
@@ -156,27 +156,11 @@ namespace grzyClothTool.Views
             var result = CustomMessageBox.Show($"Are you sure you want to delete this drawable? ({Addon.SelectedDrawable.Name})\nThis will CHANGE NUMBERS of everything after this drawable!\n\nDo you want to replace with reserved slot instead?", "Delete drawable", CustomMessageBox.CustomMessageBoxButtons.DeleteReplaceCancel);
             if (result == CustomMessageBox.CustomMessageBoxResult.Delete)
             {
-                DeleteDrawable(Addon.SelectedDrawable);
+                MainWindow.AddonManager.DeleteDrawable(Addon.SelectedDrawable);
             }
             else if (result == CustomMessageBox.CustomMessageBoxResult.Replace)
             {
                 ReplaceDrawable(Addon.SelectedDrawable);
-            }
-        }
-
-        private void DeleteDrawable(GDrawable drawable)
-        {
-            Addon.Drawables.Remove(drawable);
-            Addon.Drawables.Sort(true);
-            SaveHelper.SetUnsavedChanges(true);
-
-            if (SettingsHelper.Instance.AutoDeleteFiles)
-            {
-                foreach (var texture in drawable.Textures)
-                {
-                    File.Delete(texture.FilePath);
-                }
-                File.Delete(drawable.FilePath);
             }
         }
 
@@ -195,9 +179,13 @@ namespace grzyClothTool.Views
             {
                 var addon = e.AddedItems[0] as Addon;
                 int index = int.Parse(addon.Name.ToString().Split(' ')[1]) - 1;
-                Addon = MainWindow.AddonManager.Addons.ElementAt(index);
 
-                MainWindow.AddonManager.SelectedAddon = Addon;
+                // as we are modyfing the collection, we need to use try-catch
+                try
+                {
+                    Addon = MainWindow.AddonManager.Addons.ElementAt(index);
+                    MainWindow.AddonManager.SelectedAddon = Addon;
+                } catch (Exception)  { }
             }
         }
 


### PR DESCRIPTION
- Removed HasMale/HasFemale and replaced them with the HasSex method. This prevents creating empty addons when all drawables of a given sex are removed or changed. It removes the necessity of checking if the addon contains drawables of a given sex each time a drawable is added/removed/changed.
HasProp could also be changed but didn't do it because the tool doesn't allow to change between "component" and "prop".
- Created the AddDrawable method. Changing type/sex didn't check if it exceeded the drawable limit, and if it did, the drawable wasn't moved to the next available addon or a new one wasn't created. This is now all handled within the AddDrawable method.
- Moved and refactored the DeleteDrawable method to remove empty addons.