### PR TITLE
fix: enforce texture limit

### DIFF
--- a/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml.cs
+++ b/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml.cs
@@ -252,6 +252,14 @@ namespace grzyClothTool.Controls
 
         private void AddTexture_Click(object sender, RoutedEventArgs e)
         {
+            // calculate remaining texures that can be added
+            int remainingTextures = GlobalConstants.MAX_DRAWABLE_TEXTURES - SelectedDraw.Textures.Count;
+            if (remainingTextures <= 0)
+            {
+                Show($"You can't have more than {GlobalConstants.MAX_DRAWABLE_TEXTURES} textures per drawable!", "Error", CustomMessageBoxButtons.OKOnly, CustomMessageBoxIcon.Error);
+                return;
+            }
+
             OpenFileDialog files = new()
             {
                 Title = $"Select textures",
@@ -263,8 +271,19 @@ namespace grzyClothTool.Controls
             {
                 foreach(var file in files.FileNames)
                 {
+                    // check if we are within the limit
+                    if (remainingTextures <= 0)
+                    {
+                        // break the loop and show which texture was the last one
+                        Show($"Reached the limit of {GlobalConstants.MAX_DRAWABLE_TEXTURES} textures. Last added texture: {Path.GetFileName(file)}.", "Info", CustomMessageBoxButtons.OKOnly, CustomMessageBoxIcon.Warning);
+                        LogHelper.Log($"Reached the limit of {GlobalConstants.MAX_DRAWABLE_TEXTURES} textures. Last added texture: {Path.GetFileName(file)}.", LogType.Warning);
+                        break;
+
+                    }
                     var gtxt = new GTexture(file, SelectedDraw.TypeNumeric, SelectedDraw.Number, SelectedDraw.Textures.Count, SelectedDraw.HasSkin, SelectedDraw.IsProp);
                     SelectedDraw.Textures.Add(gtxt);
+
+                    remainingTextures--;
                 }
 
                 SaveHelper.SetUnsavedChanges(true);

--- a/grzyClothTool/GlobalConstants.cs
+++ b/grzyClothTool/GlobalConstants.cs
@@ -5,5 +5,6 @@ namespace grzyClothTool;
 public static class GlobalConstants
 {
     public const int MAX_DRAWABLES_IN_ADDON = 128; //todo: somewhere in the future, this should depend on a resource type (fivem has limit of 128, but sp and ragemp have 255 I believe)
+    public const int MAX_DRAWABLE_TEXTURES = 26;
     public static readonly Uri DISCORD_INVITE_URL = new("https://discord.gg/HCQutNhxWt");
 }

--- a/grzyClothTool/Helpers/FileHelper.cs
+++ b/grzyClothTool/Helpers/FileHelper.cs
@@ -56,7 +56,8 @@ public static class FileHelper
         var drawableRaceSuffix = Path.GetFileNameWithoutExtension(filePath)[^1..];
         var drawableHasSkin = drawableRaceSuffix == "r";
 
-        var textures = new ObservableCollection<GTexture>(matchingTextures.Select((path, txtNumber) => new GTexture(path, typeNumber, countOfType, txtNumber, drawableHasSkin, isProp)));
+        // Should we inform user, that they tried to add too many textures?
+        var textures = new ObservableCollection<GTexture>(matchingTextures.Select((path, txtNumber) => new GTexture(path, typeNumber, countOfType, txtNumber, drawableHasSkin, isProp)).Take(GlobalConstants.MAX_DRAWABLE_TEXTURES));
 
         return Task.FromResult(new GDrawable(filePath, isMale, isProp, typeNumber, countOfType, drawableHasSkin, textures));
     }


### PR DESCRIPTION
Enforces GTA V texture limit of 26
