### PR TITLE
feat: new context menu options

### DIFF
--- a/grzyClothTool/Controls/Drawable/DrawableList.xaml
+++ b/grzyClothTool/Controls/Drawable/DrawableList.xaml
@@ -22,10 +22,10 @@
                                     <MenuItem Header="Remove" Click="RemoveDrawable_Click" />
                                     <MenuItem Header="Replace" Click="ReplaceDrawable_Click" />
                                     <MenuItem Header="Open file location" Click="OpenFileLocation_Click" />
-                                    <MenuItem Header="Export" Click="ExportDrawable_Click" />
-                                    <MenuItem Header="Export with textures" Click="ExportDrawable_Click" Tag="YTD" />
-                                    <MenuItem Header="Export textures as DDS" Click="ExportDrawable_Click" Tag="DDS" />
-                                    <MenuItem Header="Export textures as PNG" Click="ExportDrawable_Click" Tag="PNG" />
+                                    <MenuItem Header="Export as YDD" Click="ExportDrawable_Click" />
+                                    <MenuItem Header="Export as YDD with textures" Click="ExportDrawable_Click" Tag="YTD" />
+                                    <MenuItem Header="Export only textures as DDS" Click="ExportDrawable_Click" Tag="DDS" />
+                                    <MenuItem Header="Export only textures as PNG" Click="ExportDrawable_Click" Tag="PNG" />
                                 </ContextMenu>
                             </Border.ContextMenu>
                             <Grid>

--- a/grzyClothTool/Controls/Drawable/DrawableList.xaml
+++ b/grzyClothTool/Controls/Drawable/DrawableList.xaml
@@ -19,7 +19,13 @@
                             <Border.ContextMenu>
                                 <ContextMenu>
                                     <MenuItem IsEnabled="False" Header="Optimize embedded textures" Click="OptimizeTexture_Click" />
+                                    <MenuItem Header="Remove" Click="RemoveDrawable_Click" />
+                                    <MenuItem Header="Replace" Click="ReplaceDrawable_Click" />
                                     <MenuItem Header="Open file location" Click="OpenFileLocation_Click" />
+                                    <MenuItem Header="Export" Click="ExportDrawable_Click" />
+                                    <MenuItem Header="Export with textures" Click="ExportDrawable_Click" Tag="YTD" />
+                                    <MenuItem Header="Export textures as DDS" Click="ExportDrawable_Click" Tag="DDS" />
+                                    <MenuItem Header="Export textures as PNG" Click="ExportDrawable_Click" Tag="PNG" />
                                 </ContextMenu>
                             </Border.ContextMenu>
                             <Grid>

--- a/grzyClothTool/Controls/Drawable/DrawableList.xaml.cs
+++ b/grzyClothTool/Controls/Drawable/DrawableList.xaml.cs
@@ -95,13 +95,14 @@ namespace grzyClothTool.Controls
             MenuItem menuItem = sender as MenuItem;
             var tag = menuItem?.Tag?.ToString();
 
-
-            // pretty ugly way of setting title, might imrpove later
             OpenFolderDialog folder = new()
             {
-                Title = tag == null ? "Select the folder to export drawable" :
-                        tag == "YTD" ? "Select the folder to export drawable with textures" :
-                        $"Select the folder to export textures as {tag}",
+                Title = tag switch
+                {
+                    "DDS" or "PNG" => $"Select the folder to export textures as {tag}",
+                    "YTD" => "Select the folder to export drawable with textures",
+                    _ => "Select the folder to export drawable"
+                },
                 Multiselect = false
             };
 
@@ -114,21 +115,18 @@ namespace grzyClothTool.Controls
 
             try
             {
-                // Export just textures
-                // this is the only case we don't export drawable, so return
-                if (tag == "DDS" || tag == "PNG") 
+                if (!string.IsNullOrEmpty(tag) && (tag == "YTD" || tag == "PNG" || tag == "DDS"))
                 {
-                    await Task.Run(() => FileHelper.SaveTexturesAsync(new List<GTexture>(drawable.Textures), folderPath, tag));
-                    return;
+                    await Task.Run(() => FileHelper.SaveTexturesAsync(new List<GTexture>(drawable.Textures), folderPath, tag).ConfigureAwait(false));
+
+                    if (tag == "DDS" || tag == "PNG")
+                    {
+                        return;
+                    }
+
                 }
 
-                // export drawable
-                await Task.Run(() => FileHelper.SaveDrawablesAsync(new List<GDrawable>([drawable]), folderPath));
-
-                if (tag == "YTD") // export drawables as YTD
-                {
-                    await Task.Run(() => FileHelper.SaveTexturesAsync(new List<GTexture>(drawable.Textures), folderPath, "YTD"));
-                }
+                await FileHelper.SaveDrawablesAsync([drawable], folderPath).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/grzyClothTool/Controls/Drawable/DrawableList.xaml.cs
+++ b/grzyClothTool/Controls/Drawable/DrawableList.xaml.cs
@@ -1,7 +1,12 @@
 ﻿using grzyClothTool.Helpers;
 using grzyClothTool.Models.Drawable;
+using grzyClothTool.Models.Texture;
+using Microsoft.Win32;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -55,6 +60,80 @@ namespace grzyClothTool.Controls
         {
             var drawable = DrawableListSelectedValue as GDrawable;
             FileHelper.OpenFileLocation(drawable.FilePath);
+        }
+
+        private void RemoveDrawable_Click(object sender, RoutedEventArgs e)
+        {
+            var drawable = DrawableListSelectedValue as GDrawable;
+            MainWindow.AddonManager.DeleteDrawable(drawable);
+        }
+
+        private void ReplaceDrawable_Click(object sender, RoutedEventArgs e)
+        {
+            var drawable = DrawableListSelectedValue as GDrawable;
+
+            OpenFileDialog files = new()
+            {
+                Title = $"Select drawable file to replace '{drawable.Name}'",
+                Filter = "Drawable files (*.ydd)|*.ydd",
+                Multiselect = false
+            };
+
+            if (files.ShowDialog() == true)
+            {
+                drawable.FilePath = files.FileName; // changing just path - might need to be updated to CreateDrawableAsync
+                SaveHelper.SetUnsavedChanges(true);
+
+                CWHelper.SendDrawableUpdateToPreview(e);
+            }
+        }
+
+        async private void ExportDrawable_Click(object sender, RoutedEventArgs e)
+        {
+            var drawable = DrawableListSelectedValue as GDrawable;
+
+            MenuItem menuItem = sender as MenuItem;
+            var tag = menuItem?.Tag?.ToString();
+
+
+            // pretty ugly way of setting title, might imrpove later
+            OpenFolderDialog folder = new()
+            {
+                Title = tag == null ? "Select the folder to export drawable" :
+                        tag == "YTD" ? "Select the folder to export drawable with textures" :
+                        $"Select the folder to export textures as {tag}",
+                Multiselect = false
+            };
+
+            if (folder.ShowDialog() != true)
+            {
+                return;
+            }
+
+            string folderPath = folder.FolderName;
+
+            try
+            {
+                // Export just textures
+                // this is the only case we don't export drawable, so return
+                if (tag == "DDS" || tag == "PNG") 
+                {
+                    await Task.Run(() => FileHelper.SaveTexturesAsync(new List<GTexture>(drawable.Textures), folderPath, tag));
+                    return;
+                }
+
+                // export drawable
+                await Task.Run(() => FileHelper.SaveDrawablesAsync(new List<GDrawable>([drawable]), folderPath));
+
+                if (tag == "YTD") // export drawables as YTD
+                {
+                    await Task.Run(() => FileHelper.SaveTexturesAsync(new List<GTexture>(drawable.Textures), folderPath, "YTD"));
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"An error occurred during export: {ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
     }
 }

--- a/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml
+++ b/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml
@@ -185,9 +185,12 @@
                                                     <Grid.ContextMenu>
                                                         <ContextMenu>
                                                             <MenuItem Header="Optimize texture" Click="OptimizeTexture_Click" />
+                                                            <MenuItem Header="Remove" Click="DeleteTexture_Click"/>
+                                                            <MenuItem Header="Replace" Click="ReplaceTexture_Click"/>
+                                                            <MenuItem Header="Open file location" Click="OpenFileLocation_Click" />
+                                                            <MenuItem Header="Export" Click="ExportTexture_Click" Tag="YTD" />
                                                             <MenuItem Header="Export texture as DDS" Click="ExportTexture_Click" Tag="DDS"/>
                                                             <MenuItem Header="Export texture as PNG" Click="ExportTexture_Click" Tag="PNG"/>
-                                                            <MenuItem Header="Open file location" Click="OpenFileLocation_Click" />
                                                         </ContextMenu>
                                                     </Grid.ContextMenu>
                                                 </Grid>

--- a/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml
+++ b/grzyClothTool/Controls/Drawable/SelectedDrawable.xaml
@@ -188,7 +188,7 @@
                                                             <MenuItem Header="Remove" Click="DeleteTexture_Click"/>
                                                             <MenuItem Header="Replace" Click="ReplaceTexture_Click"/>
                                                             <MenuItem Header="Open file location" Click="OpenFileLocation_Click" />
-                                                            <MenuItem Header="Export" Click="ExportTexture_Click" Tag="YTD" />
+                                                            <MenuItem Header="Export as YTD" Click="ExportTexture_Click" Tag="YTD" />
                                                             <MenuItem Header="Export texture as DDS" Click="ExportTexture_Click" Tag="DDS"/>
                                                             <MenuItem Header="Export texture as PNG" Click="ExportTexture_Click" Tag="PNG"/>
                                                         </ContextMenu>

--- a/grzyClothTool/Helpers/CWHelper.cs
+++ b/grzyClothTool/Helpers/CWHelper.cs
@@ -1,9 +1,12 @@
 ﻿using CodeWalker;
 using CodeWalker.GameFiles;
+using grzyClothTool.Controls;
+using grzyClothTool.Models.Drawable;
 using grzyClothTool.Models.Texture;
 using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
+using System.Linq;
 
 namespace grzyClothTool.Helpers;
 public static class CWHelper
@@ -13,6 +16,8 @@ public static class CWHelper
     public static bool IsCacheStartupEnabled => Properties.Settings.Default.GtaCacheStartup;
 
     private static readonly YtdFile _ytdFile = new();
+
+    private static Enums.SexType PrevDrawableSex;
 
     public static void Init()
     {
@@ -68,4 +73,68 @@ public static class CWHelper
         return ytd;
     }
 
+    public static YddFile CreateYddFile(GDrawable d)
+    {
+        byte[] data = File.ReadAllBytes(d.FilePath);
+
+        RpfFileEntry rpf = RpfFile.CreateResourceFileEntry(ref data, 0);
+        var decompressedData = ResourceBuilder.Decompress(data);
+        YddFile ydd = RpfFile.GetFile<YddFile>(rpf, decompressedData);
+        var drawable = ydd.Drawables.First();
+        drawable.Name = Path.GetFileNameWithoutExtension(d.Name);
+
+        drawable.IsHairScaleEnabled = d.EnableHairScale;
+        if (drawable.IsHairScaleEnabled)
+        {
+            drawable.HairScaleValue = d.HairScaleValue;
+        }
+
+        drawable.IsHighHeelsEnabled = d.EnableHighHeels;
+        if (drawable.IsHighHeelsEnabled)
+        {
+            drawable.HighHeelsValue = d.HighHeelsValue / 10;
+        }
+
+
+        return ydd;
+    }
+
+    public static void SendDrawableUpdateToPreview(EventArgs args)
+    {
+        GDrawable selectedDrawable = MainWindow.AddonManager.SelectedAddon.SelectedDrawable;
+        GTexture selectedTexture = MainWindow.AddonManager.SelectedAddon.SelectedTexture;
+
+        var ydd = CreateYddFile(selectedDrawable);
+        YtdFile ytd = null;
+        if (selectedTexture != null)
+        {
+            ytd = CreateYtdFile(selectedTexture, selectedTexture.DisplayName);
+            CWForm.LoadedTexture = ytd.TextureDict;
+        }
+
+        var firstDrawable = ydd.Drawables.First();
+
+        CWForm.LoadedDrawable = firstDrawable;
+        CWForm.Refresh();
+
+        Dictionary<string, string> updateDict = [];
+        string updateName, value;
+
+        if (args is DrawableUpdatedArgs dargs)
+        {
+            updateName = dargs.UpdatedName;
+            value = dargs.Value.ToString();
+            updateDict.Add(updateName, value);
+        }
+
+        if (PrevDrawableSex != selectedDrawable.Sex)
+        {
+            PrevDrawableSex = selectedDrawable.Sex;
+            updateName = "GenderChanged";
+            value = selectedDrawable.Sex == Enums.SexType.male ? "mp_m_freemode_01" : "mp_f_freemode_01";
+            updateDict.Add(updateName, value);
+        }
+
+        CWForm.UpdateSelectedDrawable(firstDrawable, ytd?.TextureDict, updateDict);
+    }
 }

--- a/grzyClothTool/Helpers/FileHelper.cs
+++ b/grzyClothTool/Helpers/FileHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -159,6 +160,8 @@ public static class FileHelper
 
     public static async Task SaveTexturesAsync(List<GTexture> textures, string folderPath, string format)
     {
+        var timer = new Stopwatch();
+        timer.Start();
 
         // Ensure the directory exists or create it. Consider handling any exceptions if directory creation fails
         if (!Directory.Exists(folderPath))
@@ -167,32 +170,120 @@ public static class FileHelper
         }
 
 
-        // Map the format to file extension and MagickImage format. Throw an exception for unsupported formats
-        var (fileExtension, imageFormat) = format.ToUpper() switch
+        // Determine file extension
+        string fileExtension = format.ToUpper() switch
         {
-            "DDS" => (".dds", MagickFormat.Dds),
-            "PNG" => (".png", MagickFormat.Png),
+            "DDS" => ".dds",
+            "PNG" => ".png",
+            "YTD" => ".ytd",
             _ => throw new ArgumentException($"Unsupported format: {format}", nameof(format))
         };
+
+        int successfulExports = 0;
 
         // Process each texture asynchronously and save it to the specified folder
         var tasks = textures.Select(async texture =>
         {
             string filePath = Path.Combine(folderPath, $"{texture.DisplayName}{fileExtension}");
-            using var image = ImgHelper.GetImage(texture.FilePath);
-            image.Format = imageFormat;
 
-            try
+            // check if file exists
+            if (File.Exists(filePath))
             {
-                await File.WriteAllBytesAsync(filePath, image.ToByteArray());
+                LogHelper.Log($"Could not save texture: {texture.DisplayName}. Error: File already exists.", LogType.Error);
+                return;
             }
-            catch (Exception ex)
+             
+            if (fileExtension == ".ytd") 
             {
-                // Log the error and continue processing other textures
-                LogHelper.Log($"Could not save texture: {texture.DisplayName}. Error: {ex.Message}", LogType.Error);
+                // For YTD, simply copy the file
+                try
+                {
+                    await CopyAsync(texture.FilePath, filePath);
+                    successfulExports++;
+                } 
+                catch (Exception ex)
+                {
+                    // Log the error and continue processing other textures
+                    LogHelper.Log($"Could not save texture: {texture.DisplayName}. Error: {ex.Message}.", LogType.Error);
+                } 
+            }
+            else
+            {
+                using var image = ImgHelper.GetImage(texture.FilePath);
+                image.Format = format.ToUpper() switch
+                {
+                    "DDS" => MagickFormat.Dds,
+                    "PNG" => MagickFormat.Png,
+                    _ => throw new ArgumentException($"Unsupported format for MagickImage: {format}", nameof(format))
+                };
+
+                try
+                {
+                    await File.WriteAllBytesAsync(filePath, image.ToByteArray());
+                    successfulExports++;
+                }
+                catch (Exception ex)
+                {
+                    // Log the error and continue processing other textures
+                    LogHelper.Log($"Could not save texture: {texture.DisplayName}. Error: {ex.Message}.", LogType.Error);
+                }
             }
         });
 
         await Task.WhenAll(tasks);
+
+        timer.Stop();
+
+        if (successfulExports > 0)
+        {
+            LogHelper.Log($"Exported {successfulExports} texture(s) in {timer.ElapsedMilliseconds}ms");
+        }
+    }
+
+    public static async Task SaveDrawablesAsync(List<GDrawable> drawables, string folderPath)
+    {
+        var timer = new Stopwatch();
+        timer.Start();
+
+        // Ensure the directory exists or create it. Consider handling any exceptions if directory creation fails
+        if (!Directory.Exists(folderPath))
+        {
+            Directory.CreateDirectory(folderPath);
+        }
+
+        int successfulExports = 0;
+
+        // Process each drawable asynchronously and save it to the specified folder
+        var tasks = drawables.Select(async drawable =>
+        {
+            string filePath = Path.Combine(folderPath, $"{drawable.Name}{Path.GetExtension(drawable.FilePath)}");
+
+            // check if file exists
+            if (File.Exists(filePath))
+            {
+                LogHelper.Log($"Could not save drawable: {drawable.Name}. Error: File already exists.", LogType.Error);
+                return;
+            }
+
+            try
+            {
+                await CopyAsync(drawable.FilePath, filePath);
+                successfulExports++;
+            }
+            catch (Exception ex)
+            {
+                // Log the error and continue processing other textures
+                LogHelper.Log($"Could not save texture: {drawable.Name}. Error: {ex.Message}.", LogType.Error);
+            }
+        });
+
+        await Task.WhenAll(tasks);
+
+        timer.Stop();
+
+        if (successfulExports > 0)
+        {
+            LogHelper.Log($"Exported {successfulExports} drawable(s) in {timer.ElapsedMilliseconds}ms");
+        }
     }
 }

--- a/grzyClothTool/Helpers/FileHelper.cs
+++ b/grzyClothTool/Helpers/FileHelper.cs
@@ -160,9 +160,6 @@ public static class FileHelper
 
     public static async Task SaveTexturesAsync(List<GTexture> textures, string folderPath, string format)
     {
-        var timer = new Stopwatch();
-        timer.Start();
-
         // Ensure the directory exists or create it. Consider handling any exceptions if directory creation fails
         if (!Directory.Exists(folderPath))
         {
@@ -178,6 +175,8 @@ public static class FileHelper
             "YTD" => ".ytd",
             _ => throw new ArgumentException($"Unsupported format: {format}", nameof(format))
         };
+
+        ProgressHelper.Start("Started exporting textures");
 
         int successfulExports = 0;
 
@@ -232,24 +231,18 @@ public static class FileHelper
 
         await Task.WhenAll(tasks);
 
-        timer.Stop();
-
-        if (successfulExports > 0)
-        {
-            LogHelper.Log($"Exported {successfulExports} texture(s) in {timer.ElapsedMilliseconds}ms");
-        }
+        ProgressHelper.Stop($"Exported {successfulExports} texture(s) in {{0}}", true);
     }
 
     public static async Task SaveDrawablesAsync(List<GDrawable> drawables, string folderPath)
     {
-        var timer = new Stopwatch();
-        timer.Start();
-
         // Ensure the directory exists or create it. Consider handling any exceptions if directory creation fails
         if (!Directory.Exists(folderPath))
         {
             Directory.CreateDirectory(folderPath);
         }
+
+        ProgressHelper.Start("Started exporting drawables");
 
         int successfulExports = 0;
 
@@ -279,11 +272,6 @@ public static class FileHelper
 
         await Task.WhenAll(tasks);
 
-        timer.Stop();
-
-        if (successfulExports > 0)
-        {
-            LogHelper.Log($"Exported {successfulExports} drawable(s) in {timer.ElapsedMilliseconds}ms");
-        }
+        ProgressHelper.Stop($"Exported {successfulExports} drawable(s) in {{0}}", true);
     }
 }

--- a/grzyClothTool/Models/Drawable/GDrawable.cs
+++ b/grzyClothTool/Models/Drawable/GDrawable.cs
@@ -23,7 +23,19 @@ public class GDrawable : INotifyPropertyChanged
 
     public event PropertyChangedEventHandler PropertyChanged;
 
-    public string FilePath { get; set; }
+    private string _filePath;
+    public string FilePath
+    {
+        get => _filePath;
+        set
+        {
+            if (_filePath != value)
+            {
+                _filePath = value;
+                OnPropertyChanged();
+            }
+        }
+    }
 
     private bool _isNew;
     public bool IsNew


### PR DESCRIPTION
New context menu options for textures
- Remove
- Replace
- Export (YTD)

New context menu options for drawables
- Remove
- Replace
- Export (just YDD)
- Export with textures (YDD + textures as YTD)
- Export textures as DDS
- Export textures as PNG

Other changes:
- Moved code related to updating the preview from ProjectWindow to CWHelper (as discussed on Discord).
- Encapsulated logging and execution time measurement in SaveTexturesAsync.
- Added a file existence check in SaveTexturesAsync to prevent accidental overwriting.