### PR TITLE
feat: validate drawable textures count

### DIFF
--- a/grzyClothTool/Models/Drawable/GDrawable.cs
+++ b/grzyClothTool/Models/Drawable/GDrawable.cs
@@ -123,7 +123,19 @@ public class GDrawable : INotifyPropertyChanged
     public int Number { get; set; }
     public string DisplayNumber => (Number % GlobalConstants.MAX_DRAWABLES_IN_ADDON).ToString("D3");
 
-    public GDrawableDetails Details { get; set; }
+    private GDrawableDetails _details;
+    public GDrawableDetails Details
+    {
+        get => _details;
+        set
+        {
+            if (_details != value)
+            {
+                _details = value;
+                OnPropertyChanged();
+            }
+        }
+    }
 
     public string? FirstPersonPath { get; set; } = null;
     public string? ClothPhysicsPath { get; set; } = null;
@@ -287,7 +299,6 @@ public class GDrawable : INotifyPropertyChanged
     [OnDeserialized]
     private void OnDeserialized(StreamingContext context)
     {
-       
         SetDrawableName();
     }
 
@@ -344,7 +355,7 @@ public class GDrawable : INotifyPropertyChanged
         MainWindow.AddonManager.Addons.Sort(true);
     }
 
-    private void OnTexturesChanged()
+    private void OnTexturesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         if (Details == null)
         {
@@ -353,25 +364,6 @@ public class GDrawable : INotifyPropertyChanged
 
         Details.TexturesCount = Textures.Count;
         Details.Validate();
-    }
-
-    private void OnTexturesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
-    {
-        switch (e.Action)
-        {
-            case NotifyCollectionChangedAction.Add:
-                OnTexturesChanged();
-                break;
-            case NotifyCollectionChangedAction.Remove:
-                OnTexturesChanged();
-                break;
-            case NotifyCollectionChangedAction.Reset:
-                OnTexturesChanged();
-                break;
-            default:
-                break;
-
-        }
     }
 
     protected void OnPropertyChanged([CallerMemberName] string? name = null)

--- a/grzyClothTool/Models/Drawable/GDrawableDetails.cs
+++ b/grzyClothTool/Models/Drawable/GDrawableDetails.cs
@@ -73,6 +73,7 @@ public class GDrawableDetails : INotifyPropertyChanged
             var model = AllModels[detailLevel];
             if (model == null)
             {
+                IsWarning = true;
                 Tooltip += $"[{detailLevel}] Missing LOD model.\n";
                 continue;
             }
@@ -97,6 +98,7 @@ public class GDrawableDetails : INotifyPropertyChanged
             var txt = EmbeddedTextures[key];
             if (txt == null)
             {
+                IsWarning = true;
                 Tooltip += $"Missing {key} texture.\n";
                 continue;
             }
@@ -117,7 +119,7 @@ public class GDrawableDetails : INotifyPropertyChanged
         if (TexturesCount == 0)
         {
             IsWarning = true;
-            Tooltip += "Drawable lacks textures.\n";
+            Tooltip += "Drawable has no textures.\n";
         }
 
         // Remove trailing newline character

--- a/grzyClothTool/Models/Drawable/GDrawableDetails.cs
+++ b/grzyClothTool/Models/Drawable/GDrawableDetails.cs
@@ -24,6 +24,8 @@ public class GDrawableDetails : INotifyPropertyChanged
         Normal
     }
 
+    public int TexturesCount = 0;
+
     public Dictionary<DetailLevel, GDrawableModel?> AllModels { get; set; } = new()
     {
         { DetailLevel.High, null },
@@ -110,6 +112,12 @@ public class GDrawableDetails : INotifyPropertyChanged
                     Tooltip += $"[Embedded {key}] {message}\n";
                 }
             }
+        }
+
+        if (TexturesCount == 0)
+        {
+            IsWarning = true;
+            Tooltip += "Drawable lacks textures.\n";
         }
 
         // Remove trailing newline character


### PR DESCRIPTION
Added a warning for drawables that do not have textures.
Changed '(Get/Load)DrawableDetails' to instance methods, as they were only used within the class.