### PR TITLE
fix: loading saves

### DIFF
--- a/grzyClothTool/Helpers/SaveHelper.cs
+++ b/grzyClothTool/Helpers/SaveHelper.cs
@@ -144,9 +144,10 @@ public static class SaveHelper
         MainWindow.AddonManager.Addons.Clear();
         foreach (var addon in addonManager.Addons)
         {
+            addon.OnDeserialized();
             MainWindow.AddonManager.Addons.Add(addon);
         }
-
+        
         LogHelper.Log($"Loaded save: {save.SaveDate}");
     }
 

--- a/grzyClothTool/Models/Addon.cs
+++ b/grzyClothTool/Models/Addon.cs
@@ -90,6 +90,27 @@ public class Addon : INotifyPropertyChanged
         }
     }
 
+    [JsonConstructor]
+    public Addon()
+    {
+        Drawables = [];
+        SelectedDrawables = [];
+        SelectedDrawables.CollectionChanged += (sender, e) =>
+        {
+            OnPropertyChanged(nameof(IsMultipleDrawablesSelected));
+        };
+        
+    }
+    
+    public void OnDeserialized()
+    {
+        foreach (var drawable in Drawables)
+        {
+            drawable.OnDeserialized();
+        }
+        MainWindow.AddonManager.MoveMenuItems.Add(new MoveMenuItem() { Header = Name, IsEnabled = true });
+    }
+
     public Addon(string projectName)
     {
         Name = projectName;

--- a/grzyClothTool/Models/Drawable/GDrawable.cs
+++ b/grzyClothTool/Models/Drawable/GDrawable.cs
@@ -248,6 +248,12 @@ public class GDrawable : INotifyPropertyChanged
 
     public ObservableCollection<Texture.GTexture> Textures { get; set; }
 
+    [JsonConstructor]
+    public GDrawable(ObservableCollection<GTexture> textures)
+    {
+        Textures = textures;
+    }
+
     public GDrawable(string drawablePath, Enums.SexType sex, bool isProp, int compType, int count, bool hasSkin, ObservableCollection<GTexture> textures)
     {
         IsLoading = true;
@@ -296,8 +302,7 @@ public class GDrawable : INotifyPropertyChanged
 
 
     //this will be called after deserialization
-    [OnDeserialized]
-    private void OnDeserialized(StreamingContext context)
+    public void OnDeserialized()
     {
         SetDrawableName();
     }

--- a/grzyClothTool/Models/Texture/GTexture.cs
+++ b/grzyClothTool/Models/Texture/GTexture.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,8 +18,8 @@ public class GTexture : INotifyPropertyChanged
     private readonly static SemaphoreSlim _semaphore = new(3);
 
     public event PropertyChangedEventHandler PropertyChanged;
-    public string FilePath;
-    public string Extension;
+    public string FilePath { get; set; }
+    public string Extension { get; set; }
 
     public string DisplayName
     {
@@ -83,6 +84,9 @@ public class GTexture : INotifyPropertyChanged
     }
 
     public bool IsPreviewDisabled { get; set; }
+
+    [JsonConstructor]
+    public GTexture() {}
 
     public GTexture(string path, int compType, int drawableNumber, int txtNumber, bool hasSkin, bool isProp)
     {


### PR DESCRIPTION
### The problem
There was an error in deserializing JSON auto-saves files, and user couldn't open them. This was caused by:
- JsonSerializer failed to create object instances, because:
  - some classes hadn't defined constructors for them (with specific params)
   - some fields were missing setters
- Methods with `OnDeserialized` attribute had no effect (probably `System.Text.Json.Serialization` doesnt support them, or something like that)

### Solution
- Implemented missing constructors for JsonSerializer object creation
- Refactored `OnDeserialized` logic to make sure that works


*Preliminary testing confirms that auto-save files now load correctly and consistently.*