### PR TITLE
feat: add option to disable per-addon drawable limit

### DIFF
--- a/grzyClothTool/Helpers/SettingsHelper.cs
+++ b/grzyClothTool/Helpers/SettingsHelper.cs
@@ -79,6 +79,7 @@ public class SettingsHelper : INotifyPropertyChanged
         _textureResolutionLimitDiffuse = Properties.Settings.Default.TextureResolutionLimitDiffuse;
         _textureResolutionLimitNormal = Properties.Settings.Default.TextureResolutionLimitNormal;
         _textureResolutionLimitSpecular = Properties.Settings.Default.TextureResolutionLimitSpecular;
+        _disableAddonLimit = Properties.Settings.Default.DisableAddonLimit;
     }
 
     private void SetProperty<T>(ref T field, T value, string propertyName, bool revalidateDrawables = false)
@@ -129,6 +130,13 @@ public class SettingsHelper : INotifyPropertyChanged
     {
         get => _markNewDrawables;
         set => SetProperty(ref _markNewDrawables, value, nameof(MarkNewDrawables));
+    }
+
+    private bool _disableAddonLimit;
+    public bool DisableAddonLimit
+    {
+        get => _disableAddonLimit;
+        set => SetProperty(ref _disableAddonLimit, value, nameof(DisableAddonLimit));
     }
 
     protected void OnPropertyChanged(string propertyName)

--- a/grzyClothTool/Models/Addon.cs
+++ b/grzyClothTool/Models/Addon.cs
@@ -1,5 +1,6 @@
 ﻿using grzyClothTool.Collections;
 using grzyClothTool.Constants;
+using grzyClothTool.Helpers;
 using grzyClothTool.Models.Drawable;
 using grzyClothTool.Models.Other;
 using grzyClothTool.Models.Texture;
@@ -315,7 +316,7 @@ public class Addon : INotifyPropertyChanged
             var countOfType = currentAddon.Drawables.Count(x => x.TypeNumeric == typeNumeric && x.IsProp == isProp && x.Sex == sex);
 
             // If the number of drawables of this type has reached 128, move to the next addon
-            if (countOfType >= GlobalConstants.MAX_DRAWABLES_IN_ADDON)
+            if (countOfType >= GlobalConstants.MAX_DRAWABLES_IN_ADDON && !SettingsHelper.Instance.DisableAddonLimit)
             {
                 currentAddonIndex++;
                 continue;
@@ -353,7 +354,7 @@ public class Addon : INotifyPropertyChanged
                 groupedDrawables[key] = newCount;
             }
 
-            if (groupedDrawables[key] > GlobalConstants.MAX_DRAWABLES_IN_ADDON)
+            if (!SettingsHelper.Instance.DisableAddonLimit && groupedDrawables[key] > GlobalConstants.MAX_DRAWABLES_IN_ADDON)
             {
                 return false;
             }

--- a/grzyClothTool/Models/AddonManager.cs
+++ b/grzyClothTool/Models/AddonManager.cs
@@ -676,7 +676,7 @@ namespace grzyClothTool.Models
                     int countOfType = currentAddon.Drawables.Count(x => x.TypeNumeric == drawable.TypeNumeric && x.IsProp == drawable.IsProp && x.Sex == drawable.Sex);
 
                     // If the number of drawables of this type has reached 128, move to the next addon
-                    if (countOfType >= GlobalConstants.MAX_DRAWABLES_IN_ADDON)
+                    if (countOfType >= GlobalConstants.MAX_DRAWABLES_IN_ADDON && !SettingsHelper.Instance.DisableAddonLimit)
                     {
                         currentAddonIndex++;
                         continue;

--- a/grzyClothTool/Models/Drawable/GDrawable.cs
+++ b/grzyClothTool/Models/Drawable/GDrawable.cs
@@ -199,7 +199,7 @@ public class GDrawable : INotifyPropertyChanged
             }
         }
     }
-    public string DisplayNumber => (Number % GlobalConstants.MAX_DRAWABLES_IN_ADDON).ToString("D3");
+    public string DisplayNumber => (SettingsHelper.Instance.DisableAddonLimit ? Number : Number % GlobalConstants.MAX_DRAWABLES_IN_ADDON).ToString("D3");
 
     private GDrawableDetails _details;
     public GDrawableDetails Details

--- a/grzyClothTool/Properties/Settings.Designer.cs
+++ b/grzyClothTool/Properties/Settings.Designer.cs
@@ -142,5 +142,17 @@ namespace grzyClothTool.Properties {
                 this["TextureResolutionLimitSpecular"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool DisableAddonLimit {
+            get {
+                return ((bool)(this["DisableAddonLimit"]));
+            }
+            set {
+                this["DisableAddonLimit"] = value;
+            }
+        }
     }
 }

--- a/grzyClothTool/Properties/Settings.settings
+++ b/grzyClothTool/Properties/Settings.settings
@@ -32,5 +32,8 @@
     <Setting Name="TextureResolutionLimitSpecular" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">1024</Value>
     </Setting>
+    <Setting Name="DisableAddonLimit" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/grzyClothTool/Views/SettingsWindow.xaml
+++ b/grzyClothTool/Views/SettingsWindow.xaml
@@ -148,7 +148,7 @@
                             </GroupBox>
                         </StackPanel>
                         <StackPanel Margin="5" Grid.Column="1">
-                            <GroupBox Margin="0,5" Height="380" Style="{DynamicResource FixedGroupBox}">
+                            <GroupBox Margin="0,5" Height="480" Style="{DynamicResource FixedGroupBox}">
                                 <GroupBox.Header>
                                     <TextBlock FontSize="15" FontWeight="Bold" Foreground="{DynamicResource Brush950}" Text="General settings" />
                                 </GroupBox.Header>
@@ -189,6 +189,13 @@
                                             Label="Mark new drawables"
                                             Text="When enabled, new drawables will be marked with a yellow dot"
                                             IsChecked="{Binding Path=Instance.MarkNewDrawables, Source={x:Static helpers:SettingsHelper.Instance}, Mode=TwoWay}" />
+
+                                        <c:SettingsLabelCheckBox
+                                            Margin="5"
+                                            Label="Disable addon drawable limit (128)"
+                                            Text="When enabled, the 128 drawable per addon limit is not enforced — all drawables are placed in a single addon regardless of count. Only use this for SP or RageMP, not FiveM."
+                                            DisplayWarning="WARNING: FiveM enforces a hard limit of 128 drawables per addon type. Disabling this check will produce addons that exceed that limit and may cause issues on FiveM servers.&#x0a;&#x0a;Only enable this if you are targeting SP or RageMP. Are you sure?"
+                                            IsChecked="{Binding Path=Instance.DisableAddonLimit, Source={x:Static helpers:SettingsHelper.Instance}, Mode=TwoWay}" />
                                     </StackPanel>
                                 </ScrollViewer>
                             </GroupBox>


### PR DESCRIPTION
The cloth tool currently enforces a hard cap of 128 drawables per type per addon (`MAX_DRAWABLES_IN_ADDON`). When that limit is reached, a new addon is automatically created. This is correct for FiveM, which imposes this restriction at the engine level, but it is unnecessarily restrictive for SP and RageMP, where the limit is effectively 255 or higher. Users targeting those platforms had no way to opt out of the split behavior, resulting in unwanted multi-addon output.

This PR is introduces a user-facing setting `DisableAddonLimit` (boolean, default false) that, when enabled, suppresses all 128-drawable enforcement logic. The addon split never triggers, and drawable placement behaves as if the limit were infinite.

- Default is false existing behavior unchanged for all current users
- Warning dialog shown on enable, explicitly mentioning FiveM incompatibility
- Setting persists across restarts
- No changes to build/resource output logic only the addon-split trigger is bypassed